### PR TITLE
feat: v0.2.2 — Web Terminal File Manager & File Transfer

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-ARG VERSION=0.1.0
+ARG VERSION=0.2.2
 
 # ---- Stage 1: Build Go Agent binaries (always cross-compile both) ----
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS agent-builder

--- a/docs/PRD-WebTerminal-Enhancement.md
+++ b/docs/PRD-WebTerminal-Enhancement.md
@@ -1,0 +1,543 @@
+# EasyShell Web Terminal 增强 — PRD
+
+> 文档版本：v1.0  
+> 创建日期：2026-03-04  
+> 状态：Draft
+
+---
+
+## 1. 背景与现状
+
+### 1.1 当前架构
+
+```
+Browser (xterm.js) ──WebSocket──► Server (TerminalWebSocketHandler) ──WebSocket──► Agent (Go PTY via creack/pty)
+```
+
+三层代理模型：浏览器 ↔ Spring Boot Server ↔ Go Agent。消息类型通过 JSON 封装，Server 做纯转发，Agent 端创建真实 PTY 会话。
+
+### 1.2 当前能力
+
+| 能力 | 状态 |
+|------|------|
+| 交互式 Shell（PTY） | ✅ 已实现 |
+| 终端自适应缩放（FitAddon） | ✅ 已实现 |
+| 可点击链接（WebLinksAddon） | ✅ 已实现 |
+| 连接状态指示 | ✅ 已实现 |
+| 暗色主题 | ✅ 已实现（硬编码） |
+| 5000 行滚动缓冲 | ✅ 已实现 |
+| 移动端适配 | ✅ 基础适配 |
+
+### 1.3 缺失能力
+
+| 能力 | 现状 |
+|------|------|
+| 文件上传/下载 | ❌ 完全缺失 |
+| 多标签页/分屏 | ❌ 单一全屏终端 |
+| 终端内搜索 | ❌ 无搜索功能 |
+| 主题/字体自定义 | ❌ 硬编码主题 |
+| 会话保持/断线重连 | ❌ 断线即丢失 |
+| 复制粘贴增强 | ❌ 仅浏览器默认行为 |
+| 全屏模式 | ❌ 不支持 |
+| 快捷连接 | ❌ 必须从主机详情跳转 |
+
+---
+
+## 2. 目标
+
+打造一个**生产级 Web 终端**，对标 JumpServer / 1Panel 的终端体验，覆盖日常运维 80% 的场景，不再需要打开本地 SSH 客户端。
+
+### 核心原则
+
+- **渐进增强**：不破坏现有架构，在现有 WebSocket 消息协议上扩展
+- **Agent 轻量**：文件操作由 Agent 端实现（Go），不引入额外依赖
+- **前端驱动**：大部分交互逻辑在前端完成，后端保持薄转发层
+- **安全第一**：文件操作需严格鉴权，防止越权访问和数据泄露
+
+---
+
+## 3. 功能规划
+
+### P0 — 必须实现（本次迭代）
+
+#### 3.1 SFTP 文件管理器
+
+**概述**：在终端页面侧边提供可视化文件浏览器，支持上传/下载文件。
+
+**前端**：
+- 终端右侧可折叠侧边栏（Drawer 或 Split Pane），默认收起
+- 点击工具栏「文件」按钮展开文件管理面板
+- 树形/列表展示远程目录结构，支持面包屑路径导航
+- 文件操作：
+  - **上传**：点击上传按钮或拖拽文件到面板区域，支持多文件
+  - **下载**：点击文件条目的下载按钮，浏览器触发下载
+  - **新建文件夹**
+  - **删除**（二次确认）
+  - **重命名**
+- 上传/下载进度条，支持大文件分块
+- 路径输入框可手动跳转目录
+
+**后端（Server）**：
+- 新增 REST 端点（非 WebSocket，便于处理二进制流）：
+  - `GET /api/agents/{agentId}/files?path=` — 列出目录
+  - `GET /api/agents/{agentId}/files/download?path=` — 下载文件（流式）
+  - `POST /api/agents/{agentId}/files/upload?path=` — 上传文件（multipart）
+  - `POST /api/agents/{agentId}/files/mkdir?path=` — 创建目录
+  - `DELETE /api/agents/{agentId}/files?path=` — 删除文件/目录
+  - `PUT /api/agents/{agentId}/files/rename` — 重命名
+- Server 将请求转发给 Agent（通过 Agent 已有的 HTTP 回调通道或新建文件操作 WebSocket 消息类型）
+
+**Agent（Go）**：
+- 新增文件操作 HTTP 端点或 WebSocket 消息处理：
+  - 目录列表（`os.ReadDir` + `os.Stat`）
+  - 文件读取（流式写入响应）
+  - 文件写入（接收分块数据写入磁盘）
+  - 创建/删除/重命名（标准 `os` 包操作）
+- 安全限制：不允许遍历超出配置的根目录（默认 `/`，可配置）
+
+**数据流（上传示例）**：
+```
+Browser ──multipart POST──► Server /api/agents/{id}/files/upload
+Server ──forward (HTTP/WS)──► Agent (write to disk)
+Agent ──response──► Server ──response──► Browser
+```
+
+**数据流（下载示例）**：
+```
+Browser ──GET──► Server /api/agents/{id}/files/download?path=/var/log/app.log
+Server ──forward──► Agent (read file, stream)
+Agent ──stream──► Server ──stream──► Browser (SaveAs dialog)
+```
+
+#### 3.2 终端多标签页
+
+**概述**：支持在同一页面内打开多个终端会话标签页。
+
+**前端**：
+- 终端区域顶部增加标签栏（Tabs）
+- 默认打开一个终端标签，工具栏「+」按钮可新增标签
+- 每个标签独立 WebSocket 连接 + 独立 xterm.js 实例
+- 标签可关闭（关闭时断开该标签的 WebSocket）
+- 标签支持重命名（双击标签名编辑）
+- 最多支持 **8 个并发标签**（前端限制）
+
+**后端**：
+- 无需改动 — 当前架构已支持同一 Agent 的多个并发终端会话（`sessionMap` 基于 sessionId 隔离）
+
+**Agent**：
+- 无需改动 — `TerminalManager` 已支持多会话并发
+
+#### 3.3 终端内搜索
+
+**概述**：支持 Ctrl+Shift+F 在终端滚动缓冲区中搜索文本。
+
+**前端**：
+- 加载 `@xterm/addon-search`
+- 工具栏增加搜索按钮，或快捷键 `Ctrl+Shift+F` 唤出搜索框
+- 搜索框支持：向上/向下查找、大小写敏感切换、正则匹配
+- 匹配项高亮显示
+
+**后端/Agent**：无需改动（纯前端功能）
+
+#### 3.4 终端工具栏
+
+**概述**：在终端区域顶部增加工具栏，集中放置功能按钮。
+
+**工具栏按钮**：
+| 按钮 | 功能 |
+|------|------|
+| 📁 文件 | 打开/关闭 SFTP 文件管理面板 |
+| 🔍 搜索 | 打开终端内搜索框 |
+| ⊞ 新标签 | 新增终端标签 |
+| ⛶ 全屏 | 进入/退出全屏模式 |
+| ⚙ 设置 | 打开终端设置（字体、主题等） |
+| 📋 复制 | 复制当前选中内容 |
+| 📥 粘贴 | 从剪贴板粘贴 |
+
+---
+
+### P1 — 应当实现（下一迭代）
+
+#### 3.5 终端主题与字体设置
+
+- 提供 3-5 个预设主题（当前暗色、Dracula、Solarized Dark、Monokai、Light）
+- 字体大小可调（12-20px 滑块）
+- 字体族可选（JetBrains Mono、Fira Code、Cascadia Code、Courier New）
+- 设置持久化到 `localStorage`
+
+#### 3.6 断线重连
+
+- WebSocket 断开后自动尝试重连（指数退避，最多 5 次）
+- 重连成功后恢复到同一 PTY 会话（需 Agent 侧会话保活）
+- Agent 端 PTY 会话增加 **空闲超时**（默认 30 分钟无输入自动关闭）
+- 前端显示重连中状态，重连失败显示「重新连接」按钮
+
+#### 3.7 快捷连接入口
+
+- 主机列表页每行增加「终端」快捷按钮（在线主机直接跳转）
+- 支持在新浏览器标签中打开终端（`target="_blank"`）
+
+#### 3.8 右键上下文菜单
+
+- 终端区域右键菜单：复制、粘贴、选择全部、清屏、搜索
+- 替代默认浏览器右键菜单
+
+---
+
+### P2 — 可选增强（远期）
+
+#### 3.9 终端分屏
+
+- 单标签内支持水平/垂直分屏（类 tmux）
+- 每个分屏独立会话
+- 拖拽调整分屏比例
+
+#### 3.10 会话录制与回放
+
+- 后端录制终端输入/输出流（asciinema 格式）
+- 管理员可在审计页面回放历史会话
+- 录制可选开关（默认关闭，管理员可配置）
+
+#### 3.11 拖拽上传
+
+- 直接将文件从桌面拖入终端区域即可上传到当前工作目录
+- 需要 Agent 端获取 Shell 的 `cwd`（通过 `/proc/PID/cwd` 或 `lsof`）
+
+#### 3.12 命令片段
+
+- 工具栏增加「命令片段」按钮
+- 预存常用命令（如 `top`、`df -h`、`docker ps`）
+- 点击即输入到终端
+
+---
+
+## 4. 技术方案
+
+### 4.1 文件传输架构
+
+```
+方案：REST API + Agent HTTP 端点
+
+理由：
+1. 文件传输是大体积二进制数据，WebSocket JSON 不适合
+2. REST 端点天然支持 multipart upload / stream download
+3. Server 已有 Agent 通信能力（通过 AgentWebSocketHandler.sendToAgent）
+4. Agent 已有 HTTP 注册机制（httpClient），可扩展 HTTP 端点
+
+实现路径：
+- Agent 启动内嵌 HTTP Server（新增，仅监听 localhost 或配置端口）
+- Server 调用 Agent HTTP 端点完成文件操作
+- 或：通过现有 WebSocket 通道传输文件元数据 + 分块数据（fallback 方案）
+```
+
+**推荐方案**：Agent 端新增轻量 HTTP 文件服务，Server 做代理转发。原因：
+- 与终端 WebSocket 连接解耦，文件传输不阻塞终端
+- 支持 HTTP Range 请求（断点续传）
+- 天然支持并发上传/下载
+
+### 4.2 前端架构
+
+```
+terminal/
+├── index.tsx              # 主页面（标签管理 + 布局）
+├── components/
+│   ├── TerminalTabs.tsx   # 标签栏组件
+│   ├── TerminalInstance.tsx # 单个终端实例（xterm.js）
+│   ├── TerminalToolbar.tsx # 工具栏
+│   ├── FileManager.tsx    # SFTP 文件管理面板
+│   ├── FileTree.tsx       # 文件树组件
+│   ├── SearchBar.tsx      # 终端内搜索
+│   └── SettingsDrawer.tsx # 设置面板
+├── hooks/
+│   ├── useTerminal.ts     # 终端实例 Hook
+│   └── useFileManager.ts  # 文件操作 Hook
+└── types.ts               # 类型定义
+```
+
+### 4.3 WebSocket 消息扩展
+
+现有消息类型保持不变，无需扩展（文件操作走 REST）。
+
+### 4.4 Agent 端扩展
+
+```go
+agent/internal/
+├── fileserver/
+│   ├── server.go          // 嵌入式 HTTP 文件服务
+│   ├── handler.go         // 文件操作处理器
+│   └── middleware.go      // 认证中间件（Token 验证）
+├── terminal/
+│   └── terminal.go        // 现有，无改动
+└── ws/
+    └── client.go          // 现有，无改动
+```
+
+---
+
+## 5. 安全设计（重点）
+
+### 5.1 威胁模型
+
+| 威胁 | 描述 | 影响等级 |
+|------|------|---------|
+| **未授权文件访问** | 攻击者绕过鉴权直接访问 Agent 文件端点 | 严重 |
+| **路径穿越攻击** | 通过 `../` 访问系统敏感文件（如 `/etc/shadow`） | 严重 |
+| **大文件 DoS** | 上传超大文件耗尽磁盘/内存 | 高 |
+| **敏感文件泄露** | 下载系统敏感配置文件 | 高 |
+| **并发写入冲突** | 多用户同时写同一文件导致数据损坏 | 中 |
+| **中间人攻击** | Server-Agent 通信被截获 | 中 |
+| **会话劫持** | 终端 WebSocket 会话被第三方接管 | 高 |
+
+### 5.2 安全措施
+
+#### 5.2.1 认证与授权
+
+| 层级 | 措施 |
+|------|------|
+| **Browser → Server** | 现有 Spring Security 会话认证（JWT/Session Cookie） |
+| **Server → Agent** | Agent 注册时生成 **AgentToken**，每次请求携带，Server 验证 |
+| **文件操作鉴权** | Server 端校验当前用户是否有该 Agent 的操作权限（基于 RBAC） |
+
+```java
+// Server 端伪代码
+@PreAuthorize("hasPermission(#agentId, 'AGENT', 'FILE_ACCESS')")
+public ResponseEntity<?> listFiles(@PathVariable String agentId, @RequestParam String path) {
+    // 转发给 Agent
+}
+```
+
+#### 5.2.2 路径安全
+
+**Agent 端必须实现：**
+
+```go
+// 路径规范化 + 越界检测
+func sanitizePath(basePath, requestedPath string) (string, error) {
+    // 1. 清理路径
+    cleaned := filepath.Clean(requestedPath)
+    
+    // 2. 解析为绝对路径
+    absPath := filepath.Join(basePath, cleaned)
+    absPath, err := filepath.Abs(absPath)
+    if err != nil {
+        return "", err
+    }
+    
+    // 3. 确保在 basePath 内
+    if !strings.HasPrefix(absPath, filepath.Clean(basePath)) {
+        return "", errors.New("path traversal detected")
+    }
+    
+    return absPath, nil
+}
+```
+
+**配置项**：
+- `EASYSHELL_AGENT_FILE_ROOT`：文件操作根目录（默认 `/`）
+- `EASYSHELL_AGENT_FILE_READONLY`：只读模式开关（默认 `false`）
+
+#### 5.2.3 敏感文件保护
+
+**默认黑名单**（Agent 端拒绝访问）：
+
+```go
+var sensitivePatterns = []string{
+    "/etc/shadow",
+    "/etc/passwd",
+    "/etc/sudoers",
+    "/etc/ssh/ssh_host_*",
+    "**/.ssh/id_*",
+    "**/.ssh/authorized_keys",
+    "**/.gnupg/**",
+    "**/.aws/credentials",
+    "**/.kube/config",
+    "**/.*_history",      // bash_history, zsh_history 等
+    "**/.env",
+    "**/.env.*",
+    "**/secrets.*",
+    "**/credentials.*",
+}
+```
+
+**可配置白名单模式**：
+- `EASYSHELL_AGENT_FILE_WHITELIST`：设置后仅允许访问白名单目录
+
+#### 5.2.4 传输安全
+
+| 通道 | 措施 |
+|------|------|
+| Browser ↔ Server | HTTPS（TLS 1.2+） |
+| Server ↔ Agent | Agent 注册时建立 WSS 通道；HTTP 文件请求携带 HMAC 签名 |
+
+**文件请求签名（Server → Agent）**：
+
+```java
+// Server 生成签名
+String timestamp = String.valueOf(System.currentTimeMillis());
+String payload = agentId + ":" + path + ":" + timestamp;
+String signature = HmacUtils.hmacSha256Hex(agentSecret, payload);
+
+// 请求头
+X-EasyShell-Timestamp: {timestamp}
+X-EasyShell-Signature: {signature}
+```
+
+```go
+// Agent 验证签名
+func (m *AuthMiddleware) Verify(r *http.Request) bool {
+    timestamp := r.Header.Get("X-EasyShell-Timestamp")
+    signature := r.Header.Get("X-EasyShell-Signature")
+    
+    // 检查时间戳（5 分钟有效期，防重放）
+    ts, _ := strconv.ParseInt(timestamp, 10, 64)
+    if time.Now().Unix() - ts > 300 {
+        return false
+    }
+    
+    // 验证签名
+    payload := m.agentID + ":" + r.URL.Query().Get("path") + ":" + timestamp
+    expected := hmacSHA256(m.agentSecret, payload)
+    return hmac.Equal([]byte(signature), []byte(expected))
+}
+```
+
+#### 5.2.5 资源限制
+
+| 限制项 | 默认值 | 配置项 |
+|--------|--------|--------|
+| 单文件上传大小 | 500 MB | `EASYSHELL_FILE_MAX_SIZE` |
+| 并发上传数 | 3 | `EASYSHELL_FILE_MAX_CONCURRENT_UPLOADS` |
+| 目录列表最大条目 | 1000 | `EASYSHELL_FILE_MAX_LIST_ENTRIES` |
+| 下载速率限制 | 无限制 | `EASYSHELL_FILE_DOWNLOAD_RATE_LIMIT` |
+
+#### 5.2.6 审计日志
+
+**所有文件操作必须记录审计日志**：
+
+```json
+{
+  "timestamp": "2026-03-04T12:00:00Z",
+  "user": "admin",
+  "agentId": "agent-001",
+  "action": "FILE_DOWNLOAD",
+  "path": "/var/log/app.log",
+  "fileSize": 1048576,
+  "clientIp": "192.168.1.100",
+  "userAgent": "Mozilla/5.0...",
+  "result": "SUCCESS"
+}
+```
+
+**审计事件类型**：
+- `FILE_LIST` — 列出目录
+- `FILE_DOWNLOAD` — 下载文件
+- `FILE_UPLOAD` — 上传文件
+- `FILE_DELETE` — 删除文件/目录
+- `FILE_MKDIR` — 创建目录
+- `FILE_RENAME` — 重命名
+
+#### 5.2.7 终端会话安全
+
+| 措施 | 描述 |
+|------|------|
+| **会话隔离** | 每个 WebSocket 连接独立 sessionId，不可跨会话访问 |
+| **会话超时** | 无操作 30 分钟自动断开（Agent 端 PTY 关闭） |
+| **来源验证** | Server 验证 WebSocket Origin 头，防止 CSRF |
+| **会话绑定** | 会话绑定到用户 ID，用户登出时强制断开所有终端会话 |
+
+### 5.3 安全配置清单
+
+```yaml
+# Agent 配置示例
+easyshell:
+  agent:
+    file:
+      enabled: true                    # 是否启用文件操作（默认 true）
+      root: "/"                        # 文件操作根目录
+      readonly: false                  # 只读模式
+      max-size: 524288000              # 单文件最大 500MB
+      blacklist:                       # 黑名单（正则）
+        - "^/etc/shadow$"
+        - "^/etc/passwd$"
+        - ".*\\.ssh/id_.*"
+      whitelist: []                    # 白名单（设置后仅允许访问）
+    terminal:
+      idle-timeout: 1800               # 终端空闲超时（秒）
+      max-sessions: 10                 # 单 Agent 最大终端会话数
+```
+
+### 5.4 安全测试要求
+
+| 测试类型 | 测试内容 |
+|----------|----------|
+| **路径穿越** | `../../../etc/shadow`、URL 编码变种（`%2e%2e%2f`） |
+| **权限绕过** | 无 Token 访问、过期 Token、伪造签名 |
+| **大文件** | 上传 1GB 文件、并发 100 个上传请求 |
+| **敏感文件** | 访问黑名单文件、符号链接指向敏感文件 |
+| **会话劫持** | 重放旧 WebSocket 消息、跨用户 sessionId |
+
+---
+
+## 6. 里程碑
+
+| 阶段 | 内容 | 预估工作量 |
+|------|------|-----------|
+| **Phase 1** | 终端工具栏 + 多标签页 + 终端内搜索 + 全屏 | 中 |
+| **Phase 2** | SFTP 文件管理器（Agent HTTP 文件服务 + Server 代理 + 前端面板 + 安全加固） | 大 |
+| **Phase 3** | 主题设置 + 断线重连 + 快捷连接 + 右键菜单 | 中 |
+| **Phase 4** | 分屏 + 会话录制 + 拖拽上传 + 命令片段 | 大（可选） |
+
+---
+
+## 7. 验收标准
+
+### P0 功能验收
+
+- [ ] 可通过文件管理面板浏览远程目录、上传/下载文件
+- [ ] 上传 100MB 文件无超时，有进度条
+- [ ] 下载文件触发浏览器原生 SaveAs
+- [ ] 支持同时打开最多 8 个终端标签
+- [ ] 标签切换不丢失已有会话内容
+- [ ] Ctrl+Shift+F 打开搜索，可检索滚动缓冲区内容
+- [ ] 工具栏按钮全部可用
+- [ ] 全屏模式可正常进入/退出
+- [ ] 移动端适配不回退
+
+### 安全验收
+
+- [ ] 路径穿越测试全部拦截
+- [ ] 黑名单文件访问被拒绝
+- [ ] 无 Token/错误 Token 请求返回 401
+- [ ] 过期签名（超过 5 分钟）请求被拒绝
+- [ ] 超大文件上传被拒绝并返回友好错误提示
+- [ ] 所有文件操作有完整审计日志
+- [ ] 终端会话超时自动断开
+
+---
+
+## 8. 附录
+
+### 8.1 竞品参考
+
+| 产品 | 文件传输方案 | 终端特性 |
+|------|-------------|----------|
+| JumpServer | SFTP 侧边栏 + rz/sz | 多标签、会话录制、命令审计 |
+| 1Panel | 文件管理面板 | 多标签、分屏 |
+| Apache Guacamole | SFTP 虚拟文件系统 | 会话录制 |
+| Tabby | 拖拽上传 + SFTP | 分屏、主题 |
+
+### 8.2 xterm.js 插件清单
+
+| 插件 | 用途 | 当前状态 |
+|------|------|---------|
+| `@xterm/addon-fit` | 自适应尺寸 | ✅ 已使用 |
+| `@xterm/addon-web-links` | 可点击链接 | ✅ 已使用 |
+| `@xterm/addon-search` | 终端内搜索 | ❌ 待添加 |
+| `@xterm/addon-webgl` | WebGL 渲染（性能优化） | ❌ 可选 |
+| `@xterm/addon-unicode11` | Unicode 支持 | ❌ 可选 |
+
+### 8.3 相关文档
+
+- [xterm.js 官方文档](https://xtermjs.org/)
+- [JumpServer 文件管理设计](https://docs.jumpserver.org/)
+- [OWASP 路径穿越防护](https://owasp.org/www-community/attacks/Path_Traversal)

--- a/docs/SPEC-WebTerminal-Enhancement.md
+++ b/docs/SPEC-WebTerminal-Enhancement.md
@@ -1,0 +1,1466 @@
+# EasyShell Web Terminal 增强 — 技术规格说明书（Tech Spec）
+
+> 文档版本：v1.0  
+> 创建日期：2026-03-04  
+> 关联 PRD：[PRD-WebTerminal-Enhancement.md](./PRD-WebTerminal-Enhancement.md)  
+> 状态：Draft
+
+---
+
+## 目录
+
+1. [概述](#1-概述)
+2. [系统架构](#2-系统架构)
+3. [Phase 1：终端 UX 增强（前端）](#3-phase-1终端-ux-增强前端)
+4. [Phase 2：文件管理（全栈）](#4-phase-2文件管理全栈)
+5. [安全规格](#5-安全规格)
+6. [数据库变更](#6-数据库变更)
+7. [配置变更](#7-配置变更)
+8. [API 规格](#8-api-规格)
+9. [错误处理](#9-错误处理)
+10. [测试计划](#10-测试计划)
+11. [部署与兼容性](#11-部署与兼容性)
+
+---
+
+## 1. 概述
+
+### 1.1 范围
+
+本 spec 覆盖 PRD Phase 1 + Phase 2，即：
+
+| Phase | 功能 | 涉及层 |
+|-------|------|--------|
+| Phase 1 | 多标签页、终端内搜索、工具栏、全屏 | 前端 |
+| Phase 2 | SFTP 文件管理（列目录、上传、下载、删除、创建、重命名） | Agent + Server + 前端 |
+
+Phase 3/4（主题、断线重连、分屏、录制等）不在本 spec 范围内。
+
+### 1.2 现有代码结构
+
+```
+easyshell-server/   (Java 17, Spring Boot 3.5, Gradle)
+├── com.easyshell.server.common.result.R          # 统一响应包装
+├── com.easyshell.server.common.exception.BusinessException
+├── com.easyshell.server.config.SecurityConfig     # Spring Security (JWT + Stateless)
+├── com.easyshell.server.config.WebSocketConfig    # WS 端点注册
+├── com.easyshell.server.websocket.AgentWebSocketHandler  # Agent WS 管理
+├── com.easyshell.server.websocket.TerminalWebSocketHandler
+├── com.easyshell.server.model.entity.AuditLog     # 审计日志实体
+├── com.easyshell.server.service.AuditLogService   # 审计接口 (async)
+├── com.easyshell.server.controller.HostController  # REST 参考
+└── ...
+
+easyshell-agent/   (Go 1.24, 单二进制)
+├── cmd/agent/main.go                              # 入口：register → heartbeat → ws
+├── internal/client/http.go                        # HTTPClient（Server 通信）
+├── internal/ws/client.go                          # WebSocket 客户端
+├── internal/terminal/terminal.go                  # PTY 会话管理
+├── internal/config/config.go                      # YAML 配置
+└── internal/executor/...                          # 脚本执行器
+
+easyshell-web/   (React 19, TypeScript, Vite 7, Ant Design 6)
+├── src/pages/terminal/index.tsx                   # 终端页面（单会话）
+├── src/hooks/useWebSocket.ts                      # WS Hook
+└── src/router/index.tsx                           # 路由 /terminal/:agentId
+```
+
+### 1.3 关键约束
+
+- **Hibernate `ddl-auto: update`**：新增字段/表自动生成，无需手写 migration SQL
+- **Agent 零外部依赖**：不引入第三方 Go 库（`creack/pty`、`gorilla/websocket`、`gopkg.in/yaml.v3` 已有）
+- **Agent ↔ Server 通信**：已有两条通道 — HTTP（注册/心跳/结果上报）和 WebSocket（实时消息）
+- **安全模型**：Browser→Server 走 JWT（`JwtAuthenticationFilter`），Agent→Server 的 `/api/v1/agent/**` 路径当前 `permitAll()`
+- **统一响应**：所有 REST API 返回 `R<T>`（`{code, message, data}`）
+
+---
+
+## 2. 系统架构
+
+### 2.1 Phase 1 架构（无后端改动）
+
+```
+Browser (xterm.js + addons)
+  ├── TerminalTabs       ← 新增：管理多个 TerminalInstance
+  ├── TerminalInstance   ← 重构：从 index.tsx 提取，每 tab 一个
+  ├── TerminalToolbar    ← 新增：工具栏
+  └── SearchBar          ← 新增：@xterm/addon-search
+        │
+        │  WebSocket (现有协议，无改动)
+        ▼
+Server (TerminalWebSocketHandler) ─── 无改动
+        │
+        ▼
+Agent (terminal.Manager) ─── 无改动
+```
+
+### 2.2 Phase 2 架构（文件管理）
+
+```
+Browser
+  ├── FileManager        ← 新增：侧边栏文件管理面板
+  │     │
+  │     │  REST API (新增)
+  │     ▼
+  │   Server (FileProxyController)  ← 新增：代理转发
+  │     │
+  │     │  WebSocket 消息 (新增消息类型)
+  │     ▼
+  │   Agent (fileserver)  ← 新增：文件操作处理
+  │
+  └── TerminalInstance   ← 现有，无改动
+        │
+        │  WebSocket (现有协议)
+        ▼
+      Server → Agent     ← 现有通道
+```
+
+**文件操作选择 WebSocket 通道而非 Agent 独立 HTTP Server 的理由：**
+
+| 方案 | 优点 | 缺点 |
+|------|------|------|
+| Agent 开 HTTP Server | 解耦、支持 Range | Agent 需暴露端口、防火墙问题、额外鉴权 |
+| **复用现有 WebSocket 通道** | **零网络变更、已有鉴权通道、防火墙友好** | 大文件需分块、不支持 Range |
+
+**最终方案：复用 Server↔Agent 的 WebSocket 通道**，通过新增消息类型传输文件元数据和分块数据。Server 端通过 REST API 接收浏览器请求，转换为 WebSocket 消息发给 Agent，Agent 处理后通过 WebSocket 返回结果。Server 端做流式组装后返回给浏览器。
+
+**大文件上传**：Server 接收 multipart，分块（每块 256KB）通过 WS 发送；Agent 端写入临时文件，完成后原子 rename。
+
+**大文件下载**：Agent 分块（每块 256KB）通过 WS 发送；Server 端流式写入 HTTP Response（`StreamingResponseBody`）。
+
+---
+
+## 3. Phase 1：终端 UX 增强（前端）
+
+### 3.1 文件变更清单
+
+| 文件 | 操作 | 描述 |
+|------|------|------|
+| `src/pages/terminal/index.tsx` | 重构 | 提取为 TabManager + Layout |
+| `src/pages/terminal/components/TerminalInstance.tsx` | 新增 | 单终端实例（从 index.tsx 提取） |
+| `src/pages/terminal/components/TerminalTabs.tsx` | 新增 | 标签栏管理 |
+| `src/pages/terminal/components/TerminalToolbar.tsx` | 新增 | 工具栏 |
+| `src/pages/terminal/components/SearchBar.tsx` | 新增 | 终端搜索浮层 |
+| `src/pages/terminal/hooks/useTerminal.ts` | 新增 | xterm 实例生命周期 Hook |
+| `src/pages/terminal/types.ts` | 新增 | 类型定义 |
+| `src/i18n/locales/en-US.json` | 修改 | 新增 terminal.* 键 |
+| `src/i18n/locales/zh-CN.json` | 修改 | 新增 terminal.* 键 |
+| `package.json` | 修改 | 新增 `@xterm/addon-search` 依赖 |
+
+### 3.2 types.ts
+
+```typescript
+export interface TerminalTab {
+  id: string;                    // uuid
+  label: string;                 // 显示名（默认 "Terminal 1"）
+  agentId: string;               // 当前连接的 agentId
+  status: 'connecting' | 'connected' | 'disconnected';
+}
+
+export interface TerminalSettings {
+  fontSize: number;              // 12-20, 默认 14
+  fontFamily: string;            // 默认 JetBrains Mono
+  theme: 'dark' | 'dracula' | 'solarized' | 'monokai' | 'light';
+  scrollback: number;            // 默认 5000
+}
+```
+
+### 3.3 TerminalInstance.tsx
+
+从现有 `index.tsx` 提取，接收 Props：
+
+```typescript
+interface TerminalInstanceProps {
+  tabId: string;
+  agentId: string;
+  isActive: boolean;             // 是否当前可见 tab
+  onStatusChange: (tabId: string, status: ConnectionStatus) => void;
+}
+```
+
+**核心逻辑**（保留现有行为）：
+- `useEffect` 创建 `Terminal` + `FitAddon` + `WebLinksAddon` + **`SearchAddon`**（新增）
+- WebSocket 连接到 `/ws/terminal/${agentId}`
+- `isActive` 控制 `display: none` 切换（不销毁 DOM，保留会话）
+- 暴露 `ref` 方法：`searchOpen()`, `searchNext()`, `searchPrev()`, `copySelection()`, `pasteFromClipboard()`
+
+**关键实现细节**：
+- 非活跃 tab 设 `display: none`，不用 `v-if` 式销毁，避免丢失 WebSocket 连接和 terminal buffer
+- 切换到活跃时调用 `fitAddon.fit()` 重新适配尺寸
+
+### 3.4 TerminalTabs.tsx
+
+```typescript
+interface TerminalTabsProps {
+  tabs: TerminalTab[];
+  activeTabId: string;
+  onTabChange: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  onTabAdd: () => void;
+  onTabRename: (tabId: string, newLabel: string) => void;
+}
+```
+
+**实现**：
+- 使用 Ant Design `Tabs` 组件，`type="editable-card"`
+- 标签名双击进入编辑模式（`Input` 替换 `span`）
+- 最大 8 个标签，达上限后禁用「+」按钮并 tooltip 提示
+- 标签显示连接状态色点（复用现有 statusConfig）
+
+### 3.5 TerminalToolbar.tsx
+
+```typescript
+interface TerminalToolbarProps {
+  onToggleFiles: () => void;      // Phase 2
+  onSearch: () => void;
+  onAddTab: () => void;
+  onToggleFullscreen: () => void;
+  onCopy: () => void;
+  onPaste: () => void;
+  isFullscreen: boolean;
+  isFileManagerOpen: boolean;     // Phase 2
+  tabCount: number;
+  maxTabs: number;
+}
+```
+
+**实现**：
+- 横排 `Space` 包裹 `Button`（`size="small"`, `type="text"`），带 `Tooltip`
+- 文件按钮 Phase 1 中 `disabled`，Phase 2 启用
+- 全屏使用 `document.documentElement.requestFullscreen()` / `document.exitFullscreen()`
+
+### 3.6 SearchBar.tsx
+
+```typescript
+interface SearchBarProps {
+  searchAddon: SearchAddon | null;
+  visible: boolean;
+  onClose: () => void;
+}
+```
+
+**实现**：
+- 浮层定位在终端右上角（`position: absolute`）
+- `Input` + 上/下箭头按钮 + 关闭按钮
+- `Checkbox` 切换大小写敏感 / 正则模式
+- `searchAddon.findNext(term, options)` / `searchAddon.findPrevious(term, options)`
+- `Escape` 键关闭
+- 快捷键绑定：`Ctrl+Shift+F` 打开/聚焦
+
+### 3.7 index.tsx（重构后）
+
+```typescript
+const TerminalPage: React.FC = () => {
+  const { agentId } = useParams<{ agentId: string }>();
+  const [tabs, setTabs] = useState<TerminalTab[]>([初始 tab]);
+  const [activeTabId, setActiveTabId] = useState<string>(初始 id);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isFileManagerOpen, setIsFileManagerOpen] = useState(false);
+  const [searchVisible, setSearchVisible] = useState(false);
+
+  // 多 tab 管理逻辑
+  const handleAddTab = () => { /* 新建 tab, 复用当前 agentId */ };
+  const handleCloseTab = (tabId: string) => { /* 关闭 WS, 移除 tab */ };
+  const handleRenameTab = (tabId: string, label: string) => { /* 更新 label */ };
+
+  return (
+    <div style={{ height: 'var(--content-inner-height)', display: 'flex', flexDirection: 'column' }}>
+      {/* 返回按钮 + 标题 + 连接状态 (保留现有 header) */}
+      <Header ... />
+      
+      {/* 工具栏 */}
+      <TerminalToolbar ... />
+      
+      {/* 标签栏 */}
+      <TerminalTabs ... />
+      
+      {/* 终端区域 + 文件管理面板 (Phase 2) */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+        <div style={{ flex: 1, position: 'relative' }}>
+          {tabs.map(tab => (
+            <TerminalInstance
+              key={tab.id}
+              tabId={tab.id}
+              agentId={tab.agentId}
+              isActive={tab.id === activeTabId}
+              onStatusChange={handleStatusChange}
+            />
+          ))}
+          {/* 搜索浮层 */}
+          <SearchBar visible={searchVisible} ... />
+        </div>
+        
+        {/* Phase 2: FileManager 侧边栏 */}
+        {isFileManagerOpen && <FileManager agentId={agentId} />}
+      </div>
+    </div>
+  );
+};
+```
+
+### 3.8 快捷键映射
+
+| 快捷键 | 行为 |
+|--------|------|
+| `Ctrl+Shift+F` | 打开/聚焦搜索框 |
+| `Escape` | 关闭搜索框 |
+| `Enter`（搜索框内） | 查找下一个 |
+| `Shift+Enter`（搜索框内） | 查找上一个 |
+| `F11` 或全屏按钮 | 切换全屏 |
+
+### 3.9 i18n 新增键
+
+```json
+{
+  "terminal.toolbar.files": "Files",
+  "terminal.toolbar.search": "Search",
+  "terminal.toolbar.newTab": "New Tab",
+  "terminal.toolbar.fullscreen": "Fullscreen",
+  "terminal.toolbar.exitFullscreen": "Exit Fullscreen",
+  "terminal.toolbar.settings": "Settings",
+  "terminal.toolbar.copy": "Copy",
+  "terminal.toolbar.paste": "Paste",
+  "terminal.tabs.maxReached": "Maximum {{max}} tabs allowed",
+  "terminal.tabs.defaultName": "Terminal {{index}}",
+  "terminal.search.placeholder": "Search...",
+  "terminal.search.caseSensitive": "Case Sensitive",
+  "terminal.search.regex": "Regex",
+  "terminal.search.noResults": "No results found"
+}
+```
+
+---
+
+## 4. Phase 2：文件管理（全栈）
+
+### 4.1 Agent 端
+
+#### 4.1.1 新增文件
+
+| 文件路径 | 描述 |
+|----------|------|
+| `internal/fileserver/handler.go` | 文件操作核心逻辑 |
+| `internal/fileserver/security.go` | 路径校验 + 黑名单 + 权限 |
+| `internal/fileserver/types.go` | 消息类型定义 |
+
+#### 4.1.2 types.go — 消息协议
+
+```go
+package fileserver
+
+// === 请求消息（Server → Agent，通过 WebSocket）===
+
+// FileListRequest 列出目录
+type FileListRequest struct {
+    Type      string `json:"type"`      // "file_list"
+    RequestID string `json:"requestId"` // Server 生成，用于关联响应
+    Path      string `json:"path"`      // 目标目录路径
+}
+
+// FileDownloadRequest 下载文件
+type FileDownloadRequest struct {
+    Type      string `json:"type"`      // "file_download"
+    RequestID string `json:"requestId"`
+    Path      string `json:"path"`
+}
+
+// FileUploadStartRequest 开始上传
+type FileUploadStartRequest struct {
+    Type      string `json:"type"`      // "file_upload_start"
+    RequestID string `json:"requestId"`
+    Path      string `json:"path"`      // 目标文件完整路径
+    Size      int64  `json:"size"`      // 文件总大小（字节）
+}
+
+// FileUploadChunkRequest 上传分块
+type FileUploadChunkRequest struct {
+    Type      string `json:"type"`      // "file_upload_chunk"
+    RequestID string `json:"requestId"`
+    Index     int    `json:"index"`     // 分块序号（0-based）
+    Data      string `json:"data"`      // Base64 编码的分块数据
+    Final     bool   `json:"final"`     // 是否最后一块
+}
+
+// FileMkdirRequest 创建目录
+type FileMkdirRequest struct {
+    Type      string `json:"type"`      // "file_mkdir"
+    RequestID string `json:"requestId"`
+    Path      string `json:"path"`
+}
+
+// FileDeleteRequest 删除文件/目录
+type FileDeleteRequest struct {
+    Type      string `json:"type"`      // "file_delete"
+    RequestID string `json:"requestId"`
+    Path      string `json:"path"`
+}
+
+// FileRenameRequest 重命名
+type FileRenameRequest struct {
+    Type      string `json:"type"`      // "file_rename"
+    RequestID string `json:"requestId"`
+    OldPath   string `json:"oldPath"`
+    NewPath   string `json:"newPath"`
+}
+
+// === 响应消息（Agent → Server，通过 WebSocket）===
+
+// FileListResponse 目录列表响应
+type FileListResponse struct {
+    Type      string     `json:"type"`      // "file_list_result"
+    RequestID string     `json:"requestId"`
+    Success   bool       `json:"success"`
+    Error     string     `json:"error,omitempty"`
+    Path      string     `json:"path"`
+    Entries   []FileInfo `json:"entries,omitempty"`
+}
+
+type FileInfo struct {
+    Name    string `json:"name"`
+    IsDir   bool   `json:"isDir"`
+    Size    int64  `json:"size"`
+    Mode    string `json:"mode"`    // "drwxr-xr-x"
+    ModTime int64  `json:"modTime"` // Unix 时间戳（毫秒）
+}
+
+// FileDownloadChunk 下载分块响应
+type FileDownloadChunk struct {
+    Type      string `json:"type"`      // "file_download_chunk"
+    RequestID string `json:"requestId"`
+    Index     int    `json:"index"`
+    Data      string `json:"data"`      // Base64
+    Final     bool   `json:"final"`
+    TotalSize int64  `json:"totalSize"` // 仅首块携带
+}
+
+// FileOperationResult 通用操作结果
+type FileOperationResult struct {
+    Type      string `json:"type"`      // "file_result"
+    RequestID string `json:"requestId"`
+    Success   bool   `json:"success"`
+    Error     string `json:"error,omitempty"`
+}
+```
+
+#### 4.1.3 security.go — 安全核心
+
+```go
+package fileserver
+
+import (
+    "errors"
+    "fmt"
+    "os"
+    "path/filepath"
+    "regexp"
+    "strings"
+)
+
+var (
+    ErrPathTraversal    = errors.New("path traversal detected")
+    ErrAccessDenied     = errors.New("access denied: path matches blacklist")
+    ErrSymlinkTraversal = errors.New("access denied: symlink points outside root")
+    ErrReadOnly         = errors.New("write operation denied: read-only mode")
+)
+
+// SecurityConfig 文件操作安全配置
+type SecurityConfig struct {
+    Enabled         bool     // 是否启用文件操作
+    RootPath        string   // 文件操作根目录
+    ReadOnly        bool     // 只读模式
+    MaxFileSize     int64    // 单文件最大字节数
+    MaxListEntries  int      // 目录列表最大条目数
+    BlacklistRegexp []*regexp.Regexp  // 编译后的黑名单正则
+    WhitelistPaths  []string // 白名单目录（设置后仅允许这些目录）
+}
+
+// DefaultBlacklist 默认敏感文件黑名单
+var DefaultBlacklist = []string{
+    `^/etc/shadow$`,
+    `^/etc/gshadow$`,
+    `^/etc/sudoers$`,
+    `^/etc/sudoers\.d/`,
+    `^/etc/ssh/ssh_host_`,
+    `/\.ssh/id_`,
+    `/\.ssh/authorized_keys$`,
+    `/\.gnupg/`,
+    `/\.aws/credentials$`,
+    `/\.aws/config$`,
+    `/\.kube/config$`,
+    `/\.docker/config\.json$`,
+    `/\.[a-z]*_history$`,
+    `/\.env$`,
+    `/\.env\.`,
+    `/secrets?\.(ya?ml|json|toml|properties|conf)$`,
+    `/credentials?\.(ya?ml|json|toml|properties|conf)$`,
+    `/\.git/config$`,
+    `/\.gitconfig$`,
+    `/\.netrc$`,
+    `/\.pgpass$`,
+    `/private[_-]?key`,
+    `\.pem$`,
+    `\.key$`,
+}
+
+// ValidatePath 路径安全校验（核心安全函数）
+//
+// 执行以下校验：
+// 1. filepath.Clean 规范化路径
+// 2. 解析为绝对路径并校验在 RootPath 内
+// 3. Lstat 检查符号链接 → EvalSymlinks 验证真实路径仍在 RootPath 内
+// 4. 黑名单正则匹配
+// 5. 白名单检查（若配置）
+func (sc *SecurityConfig) ValidatePath(requestedPath string) (string, error) {
+    // 1. 清理路径
+    cleaned := filepath.Clean(requestedPath)
+    if cleaned == "" || cleaned == "." {
+        cleaned = "/"
+    }
+
+    // 2. 拼接 root 并解析为绝对路径
+    var absPath string
+    if filepath.IsAbs(cleaned) {
+        absPath = filepath.Join(sc.RootPath, cleaned)
+    } else {
+        absPath = filepath.Join(sc.RootPath, cleaned)
+    }
+    absPath = filepath.Clean(absPath)
+
+    // 3. Prefix 校验（防止 filepath.Join 的 .. 逃逸）
+    rootClean := filepath.Clean(sc.RootPath)
+    if absPath != rootClean && !strings.HasPrefix(absPath, rootClean+string(os.PathSeparator)) {
+        return "", ErrPathTraversal
+    }
+
+    // 4. 符号链接安全检查
+    if info, err := os.Lstat(absPath); err == nil {
+        if info.Mode()&os.ModeSymlink != 0 {
+            realPath, err := filepath.EvalSymlinks(absPath)
+            if err != nil {
+                return "", fmt.Errorf("resolve symlink: %w", err)
+            }
+            realPath = filepath.Clean(realPath)
+            if realPath != rootClean && !strings.HasPrefix(realPath, rootClean+string(os.PathSeparator)) {
+                return "", ErrSymlinkTraversal
+            }
+        }
+    }
+    // 注意：Lstat 返回 error（文件不存在）时跳过符号链接检查
+    // 这在 mkdir/upload 创建新文件时是正常的
+
+    // 5. 黑名单检查（对 absPath 执行）
+    for _, re := range sc.BlacklistRegexp {
+        if re.MatchString(absPath) {
+            return "", ErrAccessDenied
+        }
+    }
+
+    // 6. 白名单检查（若配置）
+    if len(sc.WhitelistPaths) > 0 {
+        allowed := false
+        for _, wp := range sc.WhitelistPaths {
+            wpClean := filepath.Clean(wp)
+            if absPath == wpClean || strings.HasPrefix(absPath, wpClean+string(os.PathSeparator)) {
+                allowed = true
+                break
+            }
+        }
+        if !allowed {
+            return "", ErrAccessDenied
+        }
+    }
+
+    return absPath, nil
+}
+
+// ValidateWrite 写操作前额外检查
+func (sc *SecurityConfig) ValidateWrite(requestedPath string) (string, error) {
+    if sc.ReadOnly {
+        return "", ErrReadOnly
+    }
+    return sc.ValidatePath(requestedPath)
+}
+
+// ValidateFileSize 文件大小检查
+func (sc *SecurityConfig) ValidateFileSize(size int64) error {
+    if sc.MaxFileSize > 0 && size > sc.MaxFileSize {
+        return fmt.Errorf("file size %d exceeds maximum %d bytes", size, sc.MaxFileSize)
+    }
+    return nil
+}
+```
+
+**安全校验流程图**：
+
+```
+请求路径
+   │
+   ▼
+filepath.Clean() ──── 去除 . / .. / 多余斜杠
+   │
+   ▼
+filepath.Join(root, path) ──── 拼接根目录
+   │
+   ▼
+strings.HasPrefix(abs, root) ──── 路径穿越检测
+   │  ✗ → 拒绝 (ErrPathTraversal)
+   ▼
+os.Lstat() ──── 是否符号链接？
+   │  是 → EvalSymlinks → HasPrefix 再次检查
+   │        ✗ → 拒绝 (ErrSymlinkTraversal)
+   ▼
+黑名单正则匹配 ──── 敏感文件？
+   │  是 → 拒绝 (ErrAccessDenied)
+   ▼
+白名单检查（若配置） ──── 在白名单内？
+   │  否 → 拒绝 (ErrAccessDenied)
+   ▼
+✓ 通过，返回安全绝对路径
+```
+
+#### 4.1.4 handler.go — 文件操作处理器
+
+```go
+package fileserver
+
+import (
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    "io"
+    "log/slog"
+    "os"
+    "path/filepath"
+    "sort"
+    "sync"
+)
+
+const ChunkSize = 256 * 1024  // 256KB per chunk
+
+// Handler 处理所有文件操作消息
+type Handler struct {
+    config    *SecurityConfig
+    uploads   map[string]*uploadState  // requestID → upload state
+    uploadsMu sync.Mutex
+}
+
+type uploadState struct {
+    file     *os.File
+    tempPath string
+    destPath string
+    received int64
+    expected int64
+}
+
+// NewHandler 创建文件操作处理器
+func NewHandler(config *SecurityConfig) *Handler {
+    return &Handler{
+        config:  config,
+        uploads: make(map[string]*uploadState),
+    }
+}
+
+// HandleMessage 路由文件操作消息
+func (h *Handler) HandleMessage(data []byte, send func(interface{})) {
+    var msg map[string]interface{}
+    if err := json.Unmarshal(data, &msg); err != nil {
+        slog.Error("fileserver: unmarshal error", "error", err)
+        return
+    }
+
+    msgType, _ := msg["type"].(string)
+    
+    switch msgType {
+    case "file_list":
+        h.handleList(data, send)
+    case "file_download":
+        h.handleDownload(data, send)
+    case "file_upload_start":
+        h.handleUploadStart(data, send)
+    case "file_upload_chunk":
+        h.handleUploadChunk(data, send)
+    case "file_mkdir":
+        h.handleMkdir(data, send)
+    case "file_delete":
+        h.handleDelete(data, send)
+    case "file_rename":
+        h.handleRename(data, send)
+    }
+}
+```
+
+**handleList 实现要点**：
+- `os.ReadDir(absPath)` 获取目录条目
+- 截断到 `config.MaxListEntries` 条
+- 对每个条目调用 `os.Stat` 获取 size/mode/modTime
+- 目录排在文件前面，同类按名称排序
+
+**handleDownload 实现要点**：
+- `os.Open(absPath)` + `os.Stat` 获取文件大小
+- 循环读取 256KB 块，Base64 编码后发送 `FileDownloadChunk`
+- 最后一块设 `Final: true`
+- **大文件限制**：超过 `config.MaxFileSize` 拒绝下载
+
+**handleUploadStart 实现要点**：
+- `config.ValidateWrite(path)` + `config.ValidateFileSize(size)`
+- 创建临时文件 `filepath.Dir(destPath) + "/.easyshell_upload_" + requestID`
+- 存入 `uploads` map
+
+**handleUploadChunk 实现要点**：
+- 从 `uploads` map 获取 state
+- Base64 解码 → 写入临时文件
+- `Final: true` 时 `os.Rename(tempPath, destPath)` 原子提交
+- 清理 `uploads` map
+
+**handleDelete 实现要点**：
+- `config.ValidateWrite(path)`
+- `os.Stat` 判断文件/目录
+- 目录用 `os.RemoveAll`（仅允许空目录？或确认非空目录删除？— **默认 `os.RemoveAll`，Server 端二次确认**）
+- **特殊保护**：拒绝删除 `/`、`/etc`、`/var`、`/usr`、`/home` 等系统顶级目录
+
+#### 4.1.5 ws/client.go 修改
+
+在 `handleMessage` 中新增 `file_*` 消息分发：
+
+```go
+// 现有
+case "terminal_open", "terminal_input", "terminal_resize", "terminal_close":
+    c.handleTerminalMessage(data, msg)
+
+// 新增
+case "file_list", "file_download", "file_upload_start", "file_upload_chunk",
+     "file_mkdir", "file_delete", "file_rename":
+    c.handleFileMessage(data)
+```
+
+```go
+func (c *Client) handleFileMessage(data []byte) {
+    c.fileHandler.HandleMessage(data, func(resp interface{}) {
+        if err := c.sendJSON(resp); err != nil {
+            slog.Error("failed to send file response", "error", err)
+        }
+    })
+}
+```
+
+#### 4.1.6 config.go 扩展
+
+```go
+type AgentConfig struct {
+    ID   string     `yaml:"id"`
+    File FileConfig `yaml:"file"`
+}
+
+type FileConfig struct {
+    Enabled        bool     `yaml:"enabled"`         // 默认 true
+    Root           string   `yaml:"root"`            // 默认 "/"
+    ReadOnly       bool     `yaml:"readonly"`        // 默认 false
+    MaxSizeMB      int      `yaml:"max-size-mb"`     // 默认 500
+    MaxListEntries int      `yaml:"max-list-entries"` // 默认 1000
+    Blacklist      []string `yaml:"blacklist"`       // 追加黑名单正则
+    Whitelist      []string `yaml:"whitelist"`       // 白名单目录
+}
+```
+
+### 4.2 Server 端
+
+#### 4.2.1 新增文件
+
+| 文件路径 | 描述 |
+|----------|------|
+| `controller/FileProxyController.java` | REST API 端点 |
+| `service/FileProxyService.java` | 接口 |
+| `service/impl/FileProxyServiceImpl.java` | 消息编排 + 响应聚合 |
+| `model/vo/FileInfoVO.java` | 文件信息 VO |
+| `model/dto/FileRenameRequest.java` | 重命名 DTO |
+
+#### 4.2.2 FileProxyController.java
+
+```java
+package com.easyshell.server.controller;
+
+import com.easyshell.server.common.result.R;
+import com.easyshell.server.model.dto.FileRenameRequest;
+import com.easyshell.server.model.vo.FileInfoVO;
+import com.easyshell.server.service.AuditLogService;
+import com.easyshell.server.service.FileProxyService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/agents/{agentId}/files")
+@RequiredArgsConstructor
+public class FileProxyController {
+
+    private final FileProxyService fileProxyService;
+    private final AuditLogService auditLogService;
+
+    @GetMapping
+    public R<List<FileInfoVO>> listFiles(
+            @PathVariable String agentId,
+            @RequestParam(defaultValue = "/") String path,
+            HttpServletRequest request) {
+        // 1. 校验 Agent 在线
+        // 2. 通过 WS 发送 file_list 请求，等待响应
+        // 3. 审计日志
+        List<FileInfoVO> files = fileProxyService.listFiles(agentId, path);
+        auditLog(request, agentId, "FILE_LIST", path, "SUCCESS");
+        return R.ok(files);
+    }
+
+    @GetMapping("/download")
+    public ResponseEntity<StreamingResponseBody> downloadFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            HttpServletRequest request) {
+        // 1. 通过 WS 发送 file_download 请求
+        // 2. 收集 Agent 返回的分块数据
+        // 3. StreamingResponseBody 流式写入 HTTP Response
+        // 4. 审计日志
+        auditLog(request, agentId, "FILE_DOWNLOAD", path, "SUCCESS");
+        return fileProxyService.downloadFile(agentId, path);
+    }
+
+    @PostMapping("/upload")
+    public R<Void> uploadFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            @RequestParam("file") MultipartFile file,
+            HttpServletRequest request) {
+        // 1. 校验文件大小
+        // 2. 分块发送 file_upload_start + file_upload_chunk
+        // 3. 等待 Agent 确认
+        // 4. 审计日志
+        fileProxyService.uploadFile(agentId, path, file);
+        auditLog(request, agentId, "FILE_UPLOAD", path, "SUCCESS");
+        return R.ok();
+    }
+
+    @PostMapping("/mkdir")
+    public R<Void> mkdir(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            HttpServletRequest request) {
+        fileProxyService.mkdir(agentId, path);
+        auditLog(request, agentId, "FILE_MKDIR", path, "SUCCESS");
+        return R.ok();
+    }
+
+    @DeleteMapping
+    public R<Void> deleteFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            HttpServletRequest request) {
+        fileProxyService.delete(agentId, path);
+        auditLog(request, agentId, "FILE_DELETE", path, "SUCCESS");
+        return R.ok();
+    }
+
+    @PutMapping("/rename")
+    public R<Void> rename(
+            @PathVariable String agentId,
+            @RequestBody FileRenameRequest renameRequest,
+            HttpServletRequest request) {
+        fileProxyService.rename(agentId, renameRequest.getOldPath(), renameRequest.getNewPath());
+        auditLog(request, agentId, "FILE_RENAME",
+                renameRequest.getOldPath() + " → " + renameRequest.getNewPath(), "SUCCESS");
+        return R.ok();
+    }
+
+    // 复用现有 AuditLogService
+    private void auditLog(HttpServletRequest request, String agentId,
+                          String action, String path, String result) {
+        // 从 SecurityContext 获取 userId/username
+        // 从 request 获取 clientIp
+        auditLogService.log(userId, username, action, "FILE", agentId, path, clientIp, result);
+    }
+}
+```
+
+#### 4.2.3 FileProxyServiceImpl.java — 请求-响应关联
+
+```java
+package com.easyshell.server.service.impl;
+
+import com.easyshell.server.websocket.AgentWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class FileProxyServiceImpl implements FileProxyService {
+
+    private final AgentWebSocketHandler agentHandler;
+
+    // requestId → CompletableFuture，用于关联 WS 请求和响应
+    private final Map<String, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
+
+    // 超时时间
+    private static final long LIST_TIMEOUT_SECONDS = 10;
+    private static final long DOWNLOAD_TIMEOUT_SECONDS = 300;  // 5 分钟
+    private static final long UPLOAD_TIMEOUT_SECONDS = 300;
+    private static final long OPERATION_TIMEOUT_SECONDS = 10;
+
+    @Override
+    public List<FileInfoVO> listFiles(String agentId, String path) {
+        String requestId = UUID.randomUUID().toString();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingRequests.put(requestId, future);
+
+        try {
+            // 发送请求到 Agent
+            String msg = objectMapper.writeValueAsString(Map.of(
+                "type", "file_list",
+                "requestId", requestId,
+                "path", path
+            ));
+            boolean sent = agentHandler.sendToAgent(agentId, msg);
+            if (!sent) throw new BusinessException("Agent not connected");
+
+            // 等待响应
+            String response = future.get(LIST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            // 解析 FileListResponse → List<FileInfoVO>
+            return parseFileListResponse(response);
+        } catch (TimeoutException e) {
+            throw new BusinessException("File operation timed out");
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    // Agent 响应回调（由 AgentWebSocketHandler 调用）
+    public void handleFileResponse(String requestId, String responseJson) {
+        CompletableFuture<String> future = pendingRequests.get(requestId);
+        if (future != null) {
+            future.complete(responseJson);
+        }
+    }
+}
+```
+
+#### 4.2.4 AgentWebSocketHandler.java 修改
+
+新增 `file_*_result` 消息分发：
+
+```java
+// 新增在 handleTextMessage 的 switch 中
+case "file_list_result", "file_download_chunk", "file_result" -> {
+    String requestId = node.has("requestId") ? node.get("requestId").asText() : "";
+    if (fileProxyService != null) {
+        fileProxyService.handleFileResponse(requestId, message.getPayload());
+    }
+}
+```
+
+#### 4.2.5 SecurityConfig.java 修改
+
+文件 API 端点需要认证（`/api/v1/agents/{agentId}/files/**` 不在 `permitAll` 中，已自动需要 JWT）。
+
+**无需改动** — 当前 `anyRequest().authenticated()` 已覆盖。
+
+#### 4.2.6 FileInfoVO.java
+
+```java
+package com.easyshell.server.model.vo;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FileInfoVO {
+    private String name;
+    private boolean isDir;
+    private long size;
+    private String mode;       // "drwxr-xr-x"
+    private long modTime;      // Unix 时间戳（毫秒）
+}
+```
+
+#### 4.2.7 FileRenameRequest.java
+
+```java
+package com.easyshell.server.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class FileRenameRequest {
+    @NotBlank(message = "Old path is required")
+    private String oldPath;
+
+    @NotBlank(message = "New path is required")
+    private String newPath;
+}
+```
+
+### 4.3 前端
+
+#### 4.3.1 新增文件
+
+| 文件 | 描述 |
+|------|------|
+| `src/pages/terminal/components/FileManager.tsx` | 文件管理侧边栏主组件 |
+| `src/pages/terminal/components/FileTree.tsx` | 文件列表/树组件 |
+| `src/pages/terminal/hooks/useFileManager.ts` | 文件操作 API Hook |
+
+#### 4.3.2 useFileManager.ts
+
+```typescript
+import { useState, useCallback } from 'react';
+import { message } from 'antd';
+
+interface FileInfo {
+  name: string;
+  isDir: boolean;
+  size: number;
+  mode: string;
+  modTime: number;
+}
+
+interface UseFileManagerReturn {
+  files: FileInfo[];
+  currentPath: string;
+  loading: boolean;
+  navigate: (path: string) => Promise<void>;
+  upload: (path: string, file: File) => Promise<void>;
+  download: (path: string, fileName: string) => Promise<void>;
+  mkdir: (path: string) => Promise<void>;
+  remove: (path: string) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+}
+
+export function useFileManager(agentId: string): UseFileManagerReturn {
+  // REST API 调用
+  // GET    /api/v1/agents/${agentId}/files?path=${encodeURIComponent(path)}
+  // GET    /api/v1/agents/${agentId}/files/download?path=${encodeURIComponent(path)}
+  // POST   /api/v1/agents/${agentId}/files/upload?path=${encodeURIComponent(path)}
+  // POST   /api/v1/agents/${agentId}/files/mkdir?path=${encodeURIComponent(path)}
+  // DELETE /api/v1/agents/${agentId}/files?path=${encodeURIComponent(path)}
+  // PUT    /api/v1/agents/${agentId}/files/rename
+}
+```
+
+#### 4.3.3 FileManager.tsx
+
+```typescript
+interface FileManagerProps {
+  agentId: string;
+  onClose: () => void;
+}
+```
+
+**布局**：
+- 宽度 360px，右侧固定
+- 顶部：路径面包屑 + 手动输入框 + 刷新按钮
+- 中部工具栏：上传按钮、新建文件夹按钮
+- 主体：文件列表（Ant Design `List` 或 `Table`）
+- 每项：图标（文件夹/文件 by 类型）+ 名称 + 大小 + 修改时间 + 操作按钮（下载/重命名/删除）
+- 上传区域：Ant Design `Upload` 组件 + Dragger（拖拽区）
+
+**关键交互**：
+- 点击文件夹 → navigate 进入
+- 点击文件 → 无操作（不是编辑器）
+- 面包屑点击 → 跳转到父目录
+- 删除 → `Modal.confirm` 二次确认
+- 上传 → 进度条显示在列表底部
+
+#### 4.3.4 i18n 新增键
+
+```json
+{
+  "terminal.files.title": "File Manager",
+  "terminal.files.upload": "Upload",
+  "terminal.files.download": "Download",
+  "terminal.files.newFolder": "New Folder",
+  "terminal.files.delete": "Delete",
+  "terminal.files.rename": "Rename",
+  "terminal.files.refresh": "Refresh",
+  "terminal.files.deleteConfirm": "Are you sure you want to delete \"{{name}}\"?",
+  "terminal.files.uploadSuccess": "File uploaded successfully",
+  "terminal.files.downloadStarted": "Download started",
+  "terminal.files.operationFailed": "Operation failed: {{error}}",
+  "terminal.files.pathPlaceholder": "Enter path...",
+  "terminal.files.newFolderName": "New Folder Name",
+  "terminal.files.emptyDirectory": "Empty directory",
+  "terminal.files.fileTooLarge": "File size exceeds the maximum limit ({{max}}MB)"
+}
+```
+
+---
+
+## 5. 安全规格
+
+### 5.1 威胁-缓解矩阵
+
+| # | 威胁 | 影响 | 缓解措施 | 实现位置 |
+|---|------|------|----------|----------|
+| T1 | **路径穿越** — `../../etc/shadow` | 严重：敏感文件泄露 | `filepath.Clean` + `HasPrefix` + 符号链接检查 | `security.go:ValidatePath` |
+| T2 | **路径穿越变种** — URL 编码 `%2e%2e%2f`、空字节 `%00` | 严重：绕过路径检查 | Server 端 `URLDecoder.decode` 后再传给 Agent；Go `filepath.Clean` 处理空字节 | `FileProxyController` + `security.go` |
+| T3 | **符号链接逃逸** — `/tmp/link → /etc/shadow` | 严重：通过合法路径读取敏感文件 | `os.Lstat` 检测符号链接 → `EvalSymlinks` 解析真实路径 → 再次 Prefix 检查 | `security.go:ValidatePath` 第 4 步 |
+| T4 | **敏感文件直接访问** | 高：凭证/密钥泄露 | 正则黑名单（24 条默认规则）+ 可选白名单模式 | `security.go:DefaultBlacklist` |
+| T5 | **大文件 DoS** | 高：磁盘/内存耗尽 | Server 端 multipart 大小限制 + Agent 端 `MaxFileSize` 检查 | `application.yml` + `security.go:ValidateFileSize` |
+| T6 | **并发上传轰炸** | 高：资源耗尽 | Server 端限流（`@RateLimiter` 或 Semaphore，最大 3 并发上传/Agent） | `FileProxyServiceImpl` |
+| T7 | **未授权 Agent 文件操作** | 严重：任意文件读写 | JWT 认证（Browser→Server）+ Agent 文件操作 `config.Enabled` 开关 | `SecurityConfig.java` + `config.go` |
+| T8 | **WebSocket 消息伪造** | 高：注入文件操作消息 | Agent WS 仅接受 Server 连接（单一来源）；Server 端仅接受已认证用户的文件请求 | 架构约束 |
+| T9 | **临时文件残留** | 中：磁盘空间泄漏 | 上传超时清理临时文件；Agent 启动时清理 `.easyshell_upload_*` 残留 | `handler.go` |
+| T10 | **目录列表信息泄露** | 中：暴露系统结构 | `MaxListEntries` 限制条目数；黑名单目录不可列出内容 | `security.go` + `handler.go` |
+| T11 | **TOCTOU 竞态** | 中：在校验和操作之间文件被替换 | 使用 `O_NOFOLLOW` 打开文件（不跟随符号链接）| `handler.go` |
+| T12 | **系统目录误删** | 严重：系统不可用 | 硬编码保护列表：`/`, `/bin`, `/sbin`, `/etc`, `/usr`, `/var`, `/lib`, `/lib64`, `/boot`, `/proc`, `/sys`, `/dev` | `handler.go:handleDelete` |
+
+### 5.2 数据流安全
+
+```
+Browser ──HTTPS──► Server ──WSS──► Agent
+   │                │                │
+   │ JWT Token      │ Session Auth   │ 配置文件权限控制
+   │ in Header      │ (WS 已建立)    │ (file.enabled,
+   │                │                │  file.readonly,
+   ▼                ▼                │  blacklist, whitelist)
+验证用户身份     验证 Agent 在线      ▼
++ 权限检查      + 转发消息          执行文件操作
+                                    + 安全校验
+```
+
+### 5.3 审计日志规格
+
+**每条文件操作审计记录包含**：
+
+| 字段 | 来源 | 示例 |
+|------|------|------|
+| `userId` | `SecurityContextHolder` | `1` |
+| `username` | `SecurityContextHolder` | `admin` |
+| `action` | 硬编码常量 | `FILE_DOWNLOAD` |
+| `resourceType` | 固定值 `"FILE"` | `FILE` |
+| `resourceId` | agentId | `ag_server01` |
+| `detail` | 操作路径/描述 | `/var/log/app.log` |
+| `ip` | `request.getRemoteAddr()` | `192.168.1.100` |
+| `result` | `SUCCESS` / `FAILED` | `SUCCESS` |
+
+**审计事件完整列表**：
+
+| action | 触发条件 |
+|--------|----------|
+| `FILE_LIST` | 列出目录 |
+| `FILE_DOWNLOAD` | 下载文件 |
+| `FILE_UPLOAD` | 上传文件 |
+| `FILE_DELETE` | 删除文件或目录 |
+| `FILE_MKDIR` | 创建目录 |
+| `FILE_RENAME` | 重命名 |
+| `FILE_ACCESS_DENIED` | 任何安全校验失败（黑名单、路径穿越、只读等） |
+
+**`FILE_ACCESS_DENIED` 特别说明**：即使操作被拒绝，也必须记录审计日志，且 detail 中包含拒绝原因。这对安全事件追溯至关重要。
+
+### 5.4 安全失败行为
+
+| 场景 | 行为 |
+|------|------|
+| Agent 离线 | 返回 `400 Agent not connected`，不重试 |
+| Agent `file.enabled=false` | Agent 端静默忽略文件消息，返回 `error: file operations disabled` |
+| 路径穿越检测 | 返回 `403 Access denied`，记录 `FILE_ACCESS_DENIED` 审计 |
+| 黑名单匹配 | 返回 `403 Access denied`（不暴露黑名单规则），记录审计 |
+| 上传超限 | 返回 `413 File too large`，不写入任何数据 |
+| 操作超时 | 返回 `504 Operation timed out`，Agent 端清理临时文件 |
+
+---
+
+## 6. 数据库变更
+
+### 6.1 无新增表
+
+文件操作为无状态代理，不持久化文件元数据。审计日志复用现有 `audit_log` 表。
+
+### 6.2 audit_log 表（现有，无 DDL 改动）
+
+新增 action 值：`FILE_LIST`, `FILE_DOWNLOAD`, `FILE_UPLOAD`, `FILE_DELETE`, `FILE_MKDIR`, `FILE_RENAME`, `FILE_ACCESS_DENIED`
+
+`resourceType` 新增值：`FILE`
+
+---
+
+## 7. 配置变更
+
+### 7.1 Agent 配置（`configs/agent.yaml`）
+
+```yaml
+# 新增配置项
+agent:
+  id: ""
+  file:                              # 新增 section
+    enabled: true                    # 是否启用文件操作（默认 true）
+    root: "/"                        # 文件操作根目录（默认 /）
+    readonly: false                  # 只读模式（默认 false）
+    max-size-mb: 500                 # 单文件最大 MB（默认 500）
+    max-list-entries: 1000           # 目录列表最大条目数（默认 1000）
+    blacklist: []                    # 追加黑名单正则（在默认黑名单基础上）
+    whitelist: []                    # 白名单目录（设置后仅允许访问这些目录）
+```
+
+**向后兼容**：未配置 `file` section 时使用所有默认值，现有 Agent 无需改配置文件即可升级。
+
+### 7.2 Server 配置（`application.yml`）
+
+```yaml
+spring:
+  servlet:
+    multipart:
+      max-file-size: 500MB          # 与 Agent 端保持一致
+      max-request-size: 510MB       # 稍大于 max-file-size
+```
+
+### 7.3 前端配置
+
+无新增配置。终端设置持久化在 `localStorage` 中（Phase 3 功能，本 spec 不涉及）。
+
+---
+
+## 8. API 规格
+
+### 8.1 列出目录
+
+```
+GET /api/v1/agents/{agentId}/files?path=/var/log
+Authorization: Bearer {jwt-token}
+
+Response 200:
+{
+  "code": 200,
+  "message": "success",
+  "data": [
+    {
+      "name": "app.log",
+      "isDir": false,
+      "size": 1048576,
+      "mode": "-rw-r--r--",
+      "modTime": 1709510400000
+    },
+    {
+      "name": "nginx",
+      "isDir": true,
+      "size": 4096,
+      "mode": "drwxr-xr-x",
+      "modTime": 1709424000000
+    }
+  ]
+}
+```
+
+### 8.2 下载文件
+
+```
+GET /api/v1/agents/{agentId}/files/download?path=/var/log/app.log
+Authorization: Bearer {jwt-token}
+
+Response 200:
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="app.log"
+Content-Length: 1048576
+
+<binary stream>
+```
+
+### 8.3 上传文件
+
+```
+POST /api/v1/agents/{agentId}/files/upload?path=/home/user/uploads
+Authorization: Bearer {jwt-token}
+Content-Type: multipart/form-data; boundary=----
+
+------
+Content-Disposition: form-data; name="file"; filename="deploy.sh"
+Content-Type: application/octet-stream
+
+<binary>
+------
+
+Response 200:
+{
+  "code": 200,
+  "message": "success",
+  "data": null
+}
+```
+
+### 8.4 创建目录
+
+```
+POST /api/v1/agents/{agentId}/files/mkdir?path=/home/user/new-dir
+Authorization: Bearer {jwt-token}
+
+Response 200:
+{ "code": 200, "message": "success", "data": null }
+```
+
+### 8.5 删除文件/目录
+
+```
+DELETE /api/v1/agents/{agentId}/files?path=/home/user/old-file.txt
+Authorization: Bearer {jwt-token}
+
+Response 200:
+{ "code": 200, "message": "success", "data": null }
+```
+
+### 8.6 重命名
+
+```
+PUT /api/v1/agents/{agentId}/files/rename
+Authorization: Bearer {jwt-token}
+Content-Type: application/json
+
+{
+  "oldPath": "/home/user/old-name.txt",
+  "newPath": "/home/user/new-name.txt"
+}
+
+Response 200:
+{ "code": 200, "message": "success", "data": null }
+```
+
+### 8.7 错误响应
+
+```json
+// 403 — 安全拦截
+{ "code": 403, "message": "Access denied", "data": null }
+
+// 400 — Agent 离线
+{ "code": 400, "message": "Agent not connected", "data": null }
+
+// 413 — 文件过大
+{ "code": 413, "message": "File size exceeds maximum 500MB", "data": null }
+
+// 504 — 操作超时
+{ "code": 504, "message": "Operation timed out", "data": null }
+
+// 500 — Agent 端错误
+{ "code": 500, "message": "File operation failed: permission denied", "data": null }
+```
+
+---
+
+## 9. 错误处理
+
+### 9.1 错误分类
+
+| 层 | 错误类型 | 处理策略 |
+|----|----------|----------|
+| **前端** | 网络错误 | `message.error(i18n 错误提示)` + 重试按钮 |
+| **前端** | 业务错误（403/413/504） | `message.error(response.message)` |
+| **Server** | Agent 离线 | `BusinessException("Agent not connected")` → 400 |
+| **Server** | WS 发送失败 | `BusinessException("Failed to communicate with agent")` → 502 |
+| **Server** | 响应超时 | `BusinessException("Operation timed out")` → 504 |
+| **Agent** | 路径安全拦截 | 返回 `FileOperationResult{success: false, error: "access denied"}` |
+| **Agent** | 文件系统错误 | 返回 `FileOperationResult{success: false, error: err.Error()}` |
+| **Agent** | 磁盘满 | 返回错误 + 清理临时文件 |
+
+### 9.2 超时设置
+
+| 操作 | Server 等待超时 | Agent 端操作超时 |
+|------|----------------|-----------------|
+| 列目录 | 10s | 不限 |
+| 下载 | 300s（5 分钟） | 不限（流式） |
+| 上传 | 300s（5 分钟） | 不限（流式） |
+| 创建/删除/重命名 | 10s | 不限 |
+
+### 9.3 临时文件清理
+
+**正常流程**：上传完成 → `os.Rename(temp, dest)` → 删除无残留
+
+**异常流程**：
+1. 上传中断（WS 断开）→ Agent 端 `uploadState` 超时（5 分钟无新分块）→ 删除临时文件
+2. Agent 重启 → `main.go` 启动时扫描 `.easyshell_upload_*` 文件并删除
+3. Server 端 `CompletableFuture` 超时 → `pendingRequests` 自动清理
+
+---
+
+## 10. 测试计划
+
+### 10.1 安全测试（必须通过）
+
+| 编号 | 测试用例 | 预期结果 |
+|------|----------|----------|
+| S01 | `path=../../../etc/shadow` | 403 + 审计日志 `FILE_ACCESS_DENIED` |
+| S02 | `path=%2e%2e%2f%2e%2e%2fetc%2fshadow` | 403 |
+| S03 | `path=/tmp/link`（符号链接→`/etc/shadow`）| 403 |
+| S04 | `path=/etc/shadow` 直接访问 | 403 |
+| S05 | `path=/home/user/.ssh/id_rsa` | 403 |
+| S06 | `path=/home/user/.env` | 403 |
+| S07 | `path=/home/user/.bash_history` | 403 |
+| S08 | `path=/home/user/.aws/credentials` | 403 |
+| S09 | 上传 600MB 文件（超限） | 413 |
+| S10 | 无 JWT Token 访问文件 API | 401 |
+| S11 | Agent `file.enabled=false` | 返回 `file operations disabled` |
+| S12 | Agent `file.readonly=true` + 上传/删除 | 403 |
+| S13 | 删除 `/` | 403（系统目录保护） |
+| S14 | 删除 `/etc` | 403 |
+| S15 | 并发 10 个上传（限制 3） | 3 个成功，7 个排队或拒绝 |
+| S16 | `path=/home/user/file%00.txt` 空字节注入 | 403 或路径被清理 |
+
+### 10.2 功能测试
+
+| 编号 | 测试用例 | 预期结果 |
+|------|----------|----------|
+| F01 | 列出 `/tmp` 目录 | 返回文件列表 |
+| F02 | 上传 1KB 文本文件 | 上传成功，可列出 |
+| F03 | 上传 100MB 文件 | 上传成功，有进度 |
+| F04 | 下载文件 | 触发浏览器 SaveAs |
+| F05 | 创建目录 | 目录出现在列表中 |
+| F06 | 重命名文件 | 旧名消失，新名出现 |
+| F07 | 删除文件 | 文件从列表消失 |
+| F08 | 打开 8 个终端标签 | 全部独立工作 |
+| F09 | 打开第 9 个标签 | 被禁止，tooltip 提示 |
+| F10 | 标签切换 | 内容保留，不断线 |
+| F11 | 终端搜索 | 高亮匹配文本 |
+| F12 | 全屏切换 | 正常进入/退出 |
+| F13 | Agent 离线时文件操作 | 返回 `Agent not connected` |
+| F14 | Agent 离线时终端标签 | 连接状态变红 |
+| F15 | 所有文件操作审计日志 | `audit_log` 表有完整记录 |
+
+### 10.3 兼容性测试
+
+| 场景 | 预期 |
+|------|------|
+| 旧版 Agent（无 file handler）+ 新 Server | 文件操作返回超时错误，终端功能不受影响 |
+| 新 Agent（无 file config）+ 新 Server | 使用默认配置，文件操作正常 |
+| 移动端浏览器 | 工具栏响应式折叠，文件管理面板全宽覆盖 |
+
+---
+
+## 11. 部署与兼容性
+
+### 11.1 版本发布策略
+
+- **Agent 二进制**：版本号 ≥ `0.2.0` 支持文件操作
+- **Server/Web**：通过 Docker image 发布
+- **向后兼容**：旧 Agent 不处理 `file_*` 消息（静默忽略），Server 端超时后返回错误
+
+### 11.2 数据库迁移
+
+无 DDL 改动。`audit_log` 表的新 action 值仅为数据层面新增，不影响表结构。
+
+### 11.3 Docker Compose
+
+无配置改动。Agent 文件操作配置通过 `configs/agent.yaml` 管理。
+
+### 11.4 发布检查清单
+
+- [ ] Agent 二进制包含 `fileserver` 包
+- [ ] Server REST 端点可访问
+- [ ] `spring.servlet.multipart.max-file-size` 配置正确
+- [ ] 安全测试 S01-S16 全部通过
+- [ ] 功能测试 F01-F15 全部通过
+- [ ] 审计日志验证完整
+- [ ] 旧 Agent 兼容性验证

--- a/easyshell-agent/cmd/agent/main.go
+++ b/easyshell-agent/cmd/agent/main.go
@@ -18,9 +18,10 @@ import (
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/executor"
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/heartbeat"
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/ws"
+	"github.com/easyshell-org/easyshell/easyshell-agent/internal/fileserver"
 )
 
-var version = "0.1.0-dev"
+var version = "0.2.2-dev"
 
 func main() {
 	configPath := flag.String("config", "configs/agent.yaml", "path to config file")
@@ -86,7 +87,14 @@ func main() {
 	go hbService.Start(ctx)
 
 	exec := executor.New()
-	wsClient := ws.NewClient(cfg.Server.URL, agentID, httpClient, exec)
+
+	// Initialize file server handler
+	fileCfg := cfg.Agent.File
+	secCfg := fileserver.NewSecurityConfig(&fileCfg)
+	fileHandler := fileserver.NewHandler(secCfg)
+	fileHandler.CleanupStaleTempFiles()
+
+	wsClient := ws.NewClient(cfg.Server.URL, agentID, httpClient, exec, fileHandler)
 	go wsClient.Start(ctx)
 
 	go pollConfig(ctx, httpClient, agentID, hbService)

--- a/easyshell-agent/internal/config/config.go
+++ b/easyshell-agent/internal/config/config.go
@@ -19,7 +19,18 @@ type ServerConfig struct {
 }
 
 type AgentConfig struct {
-	ID string `yaml:"id"`
+	ID   string     `yaml:"id"`
+	File FileConfig `yaml:"file"`
+}
+
+type FileConfig struct {
+	Enabled        bool     `yaml:"enabled"`
+	Root           string   `yaml:"root"`
+	ReadOnly       bool     `yaml:"readonly"`
+	MaxSizeMB      int      `yaml:"max-size-mb"`
+	MaxListEntries int      `yaml:"max-list-entries"`
+	Blacklist      []string `yaml:"blacklist"`
+	Whitelist      []string `yaml:"whitelist"`
 }
 
 type HeartbeatConfig struct {
@@ -36,7 +47,16 @@ type LogConfig struct {
 
 func Load(path string) (*Config, error) {
 	cfg := &Config{
-		Server:    ServerConfig{URL: "http://localhost:8080"},
+		Server: ServerConfig{URL: "http://localhost:8080"},
+		Agent: AgentConfig{
+			File: FileConfig{
+				Enabled:        true,
+				Root:           "/",
+				ReadOnly:       false,
+				MaxSizeMB:      500,
+				MaxListEntries: 1000,
+			},
+		},
 		Heartbeat: HeartbeatConfig{Interval: 30},
 		Metrics:   MetricsConfig{Interval: 60},
 		Log:       LogConfig{Level: "info"},

--- a/easyshell-agent/internal/fileserver/handler.go
+++ b/easyshell-agent/internal/fileserver/handler.go
@@ -1,0 +1,416 @@
+package fileserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+var protectedPaths = map[string]bool{
+	"/": true, "/bin": true, "/sbin": true, "/etc": true,
+	"/usr": true, "/var": true, "/lib": true, "/lib64": true,
+	"/boot": true, "/proc": true, "/sys": true, "/dev": true,
+	"/home": true, "/root": true, "/tmp": true, "/run": true,
+	"/opt": true, "/srv": true, "/mnt": true, "/media": true,
+}
+
+type uploadState struct {
+	file      *os.File
+	tempPath  string
+	destPath  string
+	received  int64
+	expected  int64
+}
+
+type Handler struct {
+	config    *SecurityConfig
+	uploads   map[string]*uploadState
+	uploadsMu sync.Mutex
+}
+
+const ChunkSize = 256 * 1024
+
+func NewHandler(config *SecurityConfig) *Handler {
+	return &Handler{
+		config:  config,
+		uploads: make(map[string]*uploadState),
+	}
+}
+
+func (h *Handler) HandleMessage(data []byte, send func(interface{})) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		slog.Error("failed to decode file message", "error", err)
+		return
+	}
+
+	msgType, _ := raw["type"].(string)
+	reqID, _ := raw["requestId"].(string)
+
+	if !h.config.Enabled {
+		send(FileOperationResult{
+			Type:      "file_result",
+			RequestID: reqID,
+			Success:   false,
+			Error:     "file server is disabled",
+		})
+		return
+	}
+
+	switch msgType {
+	case "file_list":
+		h.handleList(data, reqID, send)
+	case "file_download":
+		h.handleDownload(data, reqID, send)
+	case "file_upload_start":
+		h.handleUploadStart(data, reqID, send)
+	case "file_upload_chunk":
+		h.handleUploadChunk(data, reqID, send)
+	case "file_mkdir":
+		h.handleMkdir(data, reqID, send)
+	case "file_delete":
+		h.handleDelete(data, reqID, send)
+	case "file_rename":
+		h.handleRename(data, reqID, send)
+	default:
+		send(FileOperationResult{
+			Type:      "file_result",
+			RequestID: reqID,
+			Success:   false,
+			Error:     "unknown file operation type",
+		})
+	}
+}
+
+func (h *Handler) handleList(data []byte, reqID string, send func(interface{})) {
+	var req FileListRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid list request", send)
+		return
+	}
+
+	absPath, err := h.config.ValidatePath(req.Path)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	entries, err := os.ReadDir(absPath)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	var fileInfos []FileInfo
+	for _, entry := range entries {
+		if len(fileInfos) >= h.config.MaxListEntries {
+			break
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		fileInfos = append(fileInfos, FileInfo{
+			Name:    info.Name(),
+			IsDir:   info.IsDir(),
+			Size:    info.Size(),
+			Mode:    info.Mode().String(),
+			ModTime: info.ModTime().UnixMilli(),
+		})
+	}
+
+	sort.Slice(fileInfos, func(i, j int) bool {
+		if fileInfos[i].IsDir != fileInfos[j].IsDir {
+			return fileInfos[i].IsDir
+		}
+		return strings.ToLower(fileInfos[i].Name) < strings.ToLower(fileInfos[j].Name)
+	})
+
+	send(FileListResponse{
+		Type:      "file_list_result",
+		RequestID: reqID,
+		Success:   true,
+		Path:      req.Path,
+		Entries:   fileInfos,
+	})
+}
+
+func (h *Handler) handleDownload(data []byte, reqID string, send func(interface{})) {
+	var req FileDownloadRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid download request", send)
+		return
+	}
+
+	absPath, err := h.config.ValidatePath(req.Path)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+	if info.IsDir() {
+		h.sendError(reqID, "cannot download directory", send)
+		return
+	}
+	if err := h.config.ValidateFileSize(info.Size()); err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	file, err := os.Open(absPath)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+	defer file.Close()
+
+	buf := make([]byte, ChunkSize)
+	index := 0
+	totalSize := info.Size()
+
+	for {
+		n, err := file.Read(buf)
+		if n > 0 {
+			// Check if this is the last chunk by seeing if we've read to EOF
+			// or if the next read would be EOF
+			isFinal := err == io.EOF
+			if !isFinal && n < ChunkSize {
+				// If we read less than a full chunk and no error, peek ahead
+				// This handles cases where Read returns partial data before EOF
+				isFinal = true
+			}
+			chunk := FileDownloadChunk{
+				Type:      "file_download_chunk",
+				RequestID: reqID,
+				Index:     index,
+				Data:      base64.StdEncoding.EncodeToString(buf[:n]),
+				Final:     isFinal,
+			}
+			if index == 0 {
+				chunk.TotalSize = totalSize
+			}
+			send(chunk)
+			index++
+			
+			if isFinal {
+				break
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				h.sendError(reqID, "read error: "+err.Error(), send)
+			} else if index == 0 {
+				// Empty file case
+				send(FileDownloadChunk{
+					Type:      "file_download_chunk",
+					RequestID: reqID,
+					Index:     0,
+					Data:      "",
+					Final:     true,
+					TotalSize: 0,
+				})
+			}
+			break
+		}
+	}
+}
+
+func (h *Handler) handleUploadStart(data []byte, reqID string, send func(interface{})) {
+	var req FileUploadStartRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid upload start request", send)
+		return
+	}
+
+	absPath, err := h.config.ValidateWrite(req.Path)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+	if err := h.config.ValidateFileSize(req.Size); err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(absPath), ".easyshell_upload_"+reqID+"_*")
+	if err != nil {
+		h.sendError(reqID, "failed to create temp file: "+err.Error(), send)
+		return
+	}
+
+	h.uploadsMu.Lock()
+	h.uploads[reqID] = &uploadState{
+		file:     tempFile,
+		tempPath: tempFile.Name(),
+		destPath: absPath,
+		expected: req.Size,
+	}
+	h.uploadsMu.Unlock()
+
+	send(FileOperationResult{Type: "file_result", RequestID: reqID, Success: true})
+}
+
+func (h *Handler) handleUploadChunk(data []byte, reqID string, send func(interface{})) {
+	var req FileUploadChunkRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid upload chunk request", send)
+		return
+	}
+
+	h.uploadsMu.Lock()
+	state, ok := h.uploads[reqID]
+	h.uploadsMu.Unlock()
+
+	if !ok {
+		h.sendError(reqID, "upload session not found", send)
+		return
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		h.sendError(reqID, "invalid base64 chunk", send)
+		return
+	}
+
+	n, err := state.file.Write(decoded)
+	if err != nil {
+		h.sendError(reqID, "write error: "+err.Error(), send)
+		return
+	}
+	state.received += int64(n)
+
+	if req.Final {
+		state.file.Close()
+		h.uploadsMu.Lock()
+		delete(h.uploads, reqID)
+		h.uploadsMu.Unlock()
+
+		if err := os.Rename(state.tempPath, state.destPath); err != nil {
+			h.sendError(reqID, "failed to commit file: "+err.Error(), send)
+			return
+		}
+	}
+
+	send(FileOperationResult{Type: "file_result", RequestID: reqID, Success: true})
+}
+
+func (h *Handler) handleMkdir(data []byte, reqID string, send func(interface{})) {
+	var req FileMkdirRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid mkdir request", send)
+		return
+	}
+
+	absPath, err := h.config.ValidateWrite(req.Path)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	if err := os.MkdirAll(absPath, 0755); err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	send(FileOperationResult{Type: "file_result", RequestID: reqID, Success: true})
+}
+
+func (h *Handler) handleDelete(data []byte, reqID string, send func(interface{})) {
+	var req FileDeleteRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid delete request", send)
+		return
+	}
+
+	absPath, err := h.config.ValidateWrite(req.Path)
+	if err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	if protectedPaths[absPath] {
+		h.sendError(reqID, "cannot delete system protected directory", send)
+		return
+	}
+
+	if err := os.RemoveAll(absPath); err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	send(FileOperationResult{Type: "file_result", RequestID: reqID, Success: true})
+}
+
+func (h *Handler) handleRename(data []byte, reqID string, send func(interface{})) {
+	var req FileRenameRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		h.sendError(reqID, "invalid rename request", send)
+		return
+	}
+
+	oldAbs, err := h.config.ValidateWrite(req.OldPath)
+	if err != nil {
+		h.sendError(reqID, "old path: "+err.Error(), send)
+		return
+	}
+	newAbs, err := h.config.ValidateWrite(req.NewPath)
+	if err != nil {
+		h.sendError(reqID, "new path: "+err.Error(), send)
+		return
+	}
+
+	if protectedPaths[oldAbs] {
+		h.sendError(reqID, "cannot rename system protected directory", send)
+		return
+	}
+
+	if err := os.Rename(oldAbs, newAbs); err != nil {
+		h.sendError(reqID, err.Error(), send)
+		return
+	}
+
+	send(FileOperationResult{Type: "file_result", RequestID: reqID, Success: true})
+}
+
+func (h *Handler) sendError(reqID string, errStr string, send func(interface{})) {
+	send(FileOperationResult{
+		Type:      "file_result",
+		RequestID: reqID,
+		Success:   false,
+		Error:     errStr,
+	})
+}
+
+func (h *Handler) CleanupStaleTempFiles() {
+	if !h.config.Enabled {
+		return
+	}
+	root := h.config.RootPath
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return filepath.SkipDir
+		}
+		if info.IsDir() {
+			if path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(filepath.Base(path), ".easyshell_upload_") {
+			slog.Info("cleaning up stale temp file", "path", path)
+			_ = os.Remove(path)
+		}
+		return nil
+	})
+}

--- a/easyshell-agent/internal/fileserver/security.go
+++ b/easyshell-agent/internal/fileserver/security.go
@@ -1,0 +1,146 @@
+package fileserver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/easyshell-org/easyshell/easyshell-agent/internal/config"
+)
+
+var (
+	ErrPathTraversal    = errors.New("path traversal detected")
+	ErrAccessDenied     = errors.New("access denied by security rules")
+	ErrSymlinkTraversal = errors.New("symlink traversal detected")
+	ErrReadOnly         = errors.New("file system is read-only")
+	ErrFileTooLarge     = errors.New("file exceeds maximum size")
+)
+
+var DefaultBlacklist = []string{
+	`^/etc/shadow$`,
+	`^/etc/gshadow$`,
+	`^/etc/sudoers$`,
+	`^/etc/sudoers\.d/`,
+	`^/etc/ssh/ssh_host_`,
+	`/\.ssh/id_`,
+	`/\.ssh/authorized_keys$`,
+	`/\.gnupg/`,
+	`/\.aws/credentials$`,
+	`/\.aws/config$`,
+	`/\.kube/config$`,
+	`/\.docker/config\.json$`,
+	`/\.[a-z]*_history$`,
+	`/\.env$`,
+	`/\.env\.`,
+	`/secrets?\.(ya?ml|json|toml|properties|conf)$`,
+	`/credentials?\.(ya?ml|json|toml|properties|conf)$`,
+	`/\.git/config$`,
+	`/\.gitconfig$`,
+	`/\.netrc$`,
+	`/\.pgpass$`,
+	`/private[_-]?key`,
+	`\.pem$`,
+	`\.key$`,
+}
+
+type SecurityConfig struct {
+	Enabled          bool
+	RootPath         string
+	ReadOnly         bool
+	MaxFileSize      int64
+	MaxListEntries   int
+	BlacklistRegexp  []*regexp.Regexp
+	WhitelistPaths   []string
+}
+
+func NewSecurityConfig(cfg *config.FileConfig) *SecurityConfig {
+	sc := &SecurityConfig{
+		Enabled:        cfg.Enabled,
+		RootPath:       filepath.Clean(cfg.Root),
+		ReadOnly:       cfg.ReadOnly,
+		MaxFileSize:    int64(cfg.MaxSizeMB) * 1024 * 1024,
+		MaxListEntries: cfg.MaxListEntries,
+		WhitelistPaths: cfg.Whitelist,
+	}
+
+	for _, pattern := range DefaultBlacklist {
+		if re, err := regexp.Compile(pattern); err == nil {
+			sc.BlacklistRegexp = append(sc.BlacklistRegexp, re)
+		}
+	}
+	for _, pattern := range cfg.Blacklist {
+		if re, err := regexp.Compile(pattern); err == nil {
+			sc.BlacklistRegexp = append(sc.BlacklistRegexp, re)
+		}
+	}
+
+	return sc
+}
+
+func (sc *SecurityConfig) ValidatePath(requestedPath string) (string, error) {
+	cleaned := filepath.Clean(requestedPath)
+	absPath := filepath.Clean(filepath.Join(sc.RootPath, cleaned))
+
+	rootClean := filepath.Clean(sc.RootPath)
+	// Special case: when root is "/", all absolute paths are valid under root
+	if rootClean == "/" {
+		if !filepath.IsAbs(absPath) {
+			return "", ErrPathTraversal
+		}
+	} else {
+		if !strings.HasPrefix(absPath, rootClean+string(os.PathSeparator)) && absPath != rootClean {
+			return "", ErrPathTraversal
+		}
+	}
+
+	if _, err := os.Lstat(absPath); err == nil {
+		evalPath, err := filepath.EvalSymlinks(absPath)
+		if err == nil {
+			evalClean := filepath.Clean(evalPath)
+			if rootClean != "/" {
+				if !strings.HasPrefix(evalClean, rootClean+string(os.PathSeparator)) && evalClean != rootClean {
+					return "", ErrSymlinkTraversal
+				}
+			}
+		}
+	}
+
+	for _, re := range sc.BlacklistRegexp {
+		if re.MatchString(absPath) {
+			return "", ErrAccessDenied
+		}
+	}
+
+	if len(sc.WhitelistPaths) > 0 {
+		allowed := false
+		for _, w := range sc.WhitelistPaths {
+			wClean := filepath.Clean(w)
+			if strings.HasPrefix(absPath, wClean+string(os.PathSeparator)) || absPath == wClean {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", ErrAccessDenied
+		}
+	}
+
+	return absPath, nil
+}
+
+func (sc *SecurityConfig) ValidateWrite(requestedPath string) (string, error) {
+	if sc.ReadOnly {
+		return "", ErrReadOnly
+	}
+	return sc.ValidatePath(requestedPath)
+}
+
+func (sc *SecurityConfig) ValidateFileSize(size int64) error {
+	if size > sc.MaxFileSize {
+		return fmt.Errorf("%w: %d > %d", ErrFileTooLarge, size, sc.MaxFileSize)
+	}
+	return nil
+}

--- a/easyshell-agent/internal/fileserver/types.go
+++ b/easyshell-agent/internal/fileserver/types.go
@@ -1,0 +1,84 @@
+package fileserver
+
+// === Request messages (Server → Agent via WebSocket) ===
+
+type FileListRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Path      string `json:"path"`
+}
+
+type FileDownloadRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Path      string `json:"path"`
+}
+
+type FileUploadStartRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Path      string `json:"path"`
+	Size      int64  `json:"size"`
+}
+
+type FileUploadChunkRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Index     int    `json:"index"`
+	Data      string `json:"data"`
+	Final     bool   `json:"final"`
+}
+
+type FileMkdirRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Path      string `json:"path"`
+}
+
+type FileDeleteRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Path      string `json:"path"`
+}
+
+type FileRenameRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	OldPath   string `json:"oldPath"`
+	NewPath   string `json:"newPath"`
+}
+
+// === Response messages (Agent → Server via WebSocket) ===
+
+type FileListResponse struct {
+	Type      string     `json:"type"`
+	RequestID string     `json:"requestId"`
+	Success   bool       `json:"success"`
+	Error     string     `json:"error,omitempty"`
+	Path      string     `json:"path"`
+	Entries   []FileInfo `json:"entries,omitempty"`
+}
+
+type FileInfo struct {
+	Name    string `json:"name"`
+	IsDir   bool   `json:"isDir"`
+	Size    int64  `json:"size"`
+	Mode    string `json:"mode"`
+	ModTime int64  `json:"modTime"`
+}
+
+type FileDownloadChunk struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Index     int    `json:"index"`
+	Data      string `json:"data"`
+	Final     bool   `json:"final"`
+	TotalSize int64  `json:"totalSize"`
+}
+
+type FileOperationResult struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+	Success   bool   `json:"success"`
+	Error     string `json:"error,omitempty"`
+}

--- a/easyshell-agent/internal/ws/client.go
+++ b/easyshell-agent/internal/ws/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/client"
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/executor"
 	"github.com/easyshell-org/easyshell/easyshell-agent/internal/terminal"
+	"github.com/easyshell-org/easyshell/easyshell-agent/internal/fileserver"
 )
 
 type Client struct {
@@ -22,6 +23,7 @@ type Client struct {
 	httpClient  *client.HTTPClient
 	executor    *executor.Executor
 	termManager *terminal.Manager
+	fileHandler *fileserver.Handler
 	conn        *websocket.Conn
 	mu          sync.Mutex
 }
@@ -48,13 +50,14 @@ type ResultMessage struct {
 	Output   string `json:"output"`
 }
 
-func NewClient(serverURL string, agentID string, httpClient *client.HTTPClient, exec *executor.Executor) *Client {
+func NewClient(serverURL string, agentID string, httpClient *client.HTTPClient, exec *executor.Executor, fileHandler *fileserver.Handler) *Client {
 	return &Client{
 		ServerURL:   serverURL,
 		AgentID:     agentID,
 		httpClient:  httpClient,
 		executor:    exec,
 		termManager: terminal.NewManager(),
+		fileHandler: fileHandler,
 	}
 }
 
@@ -155,6 +158,8 @@ func (c *Client) handleMessage(ctx context.Context, data []byte) {
 		go c.executeJob(ctx, execMsg)
 	case "terminal_open", "terminal_input", "terminal_resize", "terminal_close":
 		c.handleTerminalMessage(data, msg)
+	case "file_list", "file_download", "file_upload_start", "file_upload_chunk", "file_mkdir", "file_delete", "file_rename":
+		c.handleFileMessage(data)
 	default:
 		slog.Warn("unknown message type", "type", msgType)
 	}
@@ -285,6 +290,14 @@ func (c *Client) handleTerminalMessage(data []byte, msg map[string]interface{}) 
 			slog.Error("failed to send terminal_ready", "error", sendErr)
 		}
 	}
+}
+
+func (c *Client) handleFileMessage(data []byte) {
+	c.fileHandler.HandleMessage(data, func(resp interface{}) {
+		if err := c.sendJSON(resp); err != nil {
+			slog.Error("failed to send file response", "error", err)
+		}
+	})
 }
 
 func (c *Client) close() {

--- a/easyshell-server/src/main/java/com/easyshell/server/controller/FileProxyController.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/controller/FileProxyController.java
@@ -1,0 +1,99 @@
+package com.easyshell.server.controller;
+
+import com.easyshell.server.common.result.R;
+import com.easyshell.server.model.dto.FileRenameRequest;
+import com.easyshell.server.model.vo.FileInfoVO;
+import com.easyshell.server.service.AuditLogService;
+import com.easyshell.server.service.FileProxyService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/agents/{agentId}/files")
+@RequiredArgsConstructor
+public class FileProxyController {
+
+    private final FileProxyService fileProxyService;
+    private final AuditLogService auditLogService;
+
+    @GetMapping
+    public R<List<FileInfoVO>> listFiles(
+            @PathVariable String agentId,
+            @RequestParam(defaultValue = "/") String path,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        List<FileInfoVO> files = fileProxyService.listFiles(agentId, path);
+        auditLogService.log(userId, auth.getName(), "FILE_LIST", "FILE",
+                agentId, path, httpRequest.getRemoteAddr(), "success");
+        return R.ok(files);
+    }
+
+    @GetMapping("/download")
+    public ResponseEntity<StreamingResponseBody> downloadFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        auditLogService.log(userId, auth.getName(), "FILE_DOWNLOAD", "FILE",
+                agentId, path, httpRequest.getRemoteAddr(), "success");
+        return fileProxyService.downloadFile(agentId, path);
+    }
+
+    @PostMapping("/upload")
+    public R<Void> uploadFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            @RequestParam("file") MultipartFile file,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        fileProxyService.uploadFile(agentId, path, file);
+        auditLogService.log(userId, auth.getName(), "FILE_UPLOAD", "FILE",
+                agentId, path + "/" + file.getOriginalFilename(), httpRequest.getRemoteAddr(), "success");
+        return R.ok();
+    }
+
+    @PostMapping("/mkdir")
+    public R<Void> mkdir(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        fileProxyService.mkdir(agentId, path);
+        auditLogService.log(userId, auth.getName(), "FILE_MKDIR", "FILE",
+                agentId, path, httpRequest.getRemoteAddr(), "success");
+        return R.ok();
+    }
+
+    @DeleteMapping
+    public R<Void> deleteFile(
+            @PathVariable String agentId,
+            @RequestParam String path,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        fileProxyService.delete(agentId, path);
+        auditLogService.log(userId, auth.getName(), "FILE_DELETE", "FILE",
+                agentId, path, httpRequest.getRemoteAddr(), "success");
+        return R.ok();
+    }
+
+    @PutMapping("/rename")
+    public R<Void> rename(
+            @PathVariable String agentId,
+            @Valid @RequestBody FileRenameRequest renameRequest,
+            Authentication auth, HttpServletRequest httpRequest) {
+        Long userId = (Long) auth.getPrincipal();
+        fileProxyService.rename(agentId, renameRequest.getOldPath(), renameRequest.getNewPath());
+        auditLogService.log(userId, auth.getName(), "FILE_RENAME", "FILE",
+                agentId, renameRequest.getOldPath() + " → " + renameRequest.getNewPath(),
+                httpRequest.getRemoteAddr(), "success");
+        return R.ok();
+    }
+}

--- a/easyshell-server/src/main/java/com/easyshell/server/model/dto/FileRenameRequest.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/model/dto/FileRenameRequest.java
@@ -1,0 +1,13 @@
+package com.easyshell.server.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class FileRenameRequest {
+    @NotBlank(message = "Old path is required")
+    private String oldPath;
+
+    @NotBlank(message = "New path is required")
+    private String newPath;
+}

--- a/easyshell-server/src/main/java/com/easyshell/server/model/vo/FileInfoVO.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/model/vo/FileInfoVO.java
@@ -1,0 +1,18 @@
+package com.easyshell.server.model.vo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FileInfoVO {
+    private String name;
+    
+    @JsonProperty("isDir")
+    private boolean dir;
+    
+    private long size;
+    private String mode;
+    private long modTime;
+}

--- a/easyshell-server/src/main/java/com/easyshell/server/service/FileProxyService.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/service/FileProxyService.java
@@ -1,0 +1,18 @@
+package com.easyshell.server.service;
+
+import com.easyshell.server.model.vo.FileInfoVO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.util.List;
+
+public interface FileProxyService {
+    List<FileInfoVO> listFiles(String agentId, String path);
+    ResponseEntity<StreamingResponseBody> downloadFile(String agentId, String path);
+    void uploadFile(String agentId, String path, MultipartFile file);
+    void mkdir(String agentId, String path);
+    void delete(String agentId, String path);
+    void rename(String agentId, String oldPath, String newPath);
+    void handleFileResponse(String requestId, String responseJson);
+}

--- a/easyshell-server/src/main/java/com/easyshell/server/service/impl/FileProxyServiceImpl.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/service/impl/FileProxyServiceImpl.java
@@ -1,0 +1,424 @@
+package com.easyshell.server.service.impl;
+
+import com.easyshell.server.common.exception.BusinessException;
+import com.easyshell.server.model.vo.FileInfoVO;
+import com.easyshell.server.service.FileProxyService;
+import com.easyshell.server.websocket.AgentWebSocketHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileProxyServiceImpl implements FileProxyService {
+
+    private final AgentWebSocketHandler agentHandler;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Map<String, CompletableFuture<String>> pendingRequests = new ConcurrentHashMap<>();
+    // For download: accumulate chunks
+    private final Map<String, BlockingQueue<String>> downloadQueues = new ConcurrentHashMap<>();
+
+    private static final long LIST_TIMEOUT_SECONDS = 10;
+    private static final long DOWNLOAD_TIMEOUT_SECONDS = 86400; // 24h — effectively unlimited
+    private static final long UPLOAD_TIMEOUT_SECONDS = 86400; // 24h — effectively unlimited
+    private static final long OPERATION_TIMEOUT_SECONDS = 10;
+    private static final int CHUNK_SIZE = 256 * 1024; // 256KB
+    private static final int MAX_CHUNK_RETRIES = 3;
+
+    @PostConstruct
+    public void init() {
+        agentHandler.setFileProxyService(this);
+    }
+
+    @Override
+    public List<FileInfoVO> listFiles(String agentId, String path) {
+        String requestId = UUID.randomUUID().toString();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingRequests.put(requestId, future);
+
+        try {
+            Map<String, Object> msg = Map.of(
+                "type", "file_list",
+                "requestId", requestId,
+                "path", path
+            );
+            sendToAgent(agentId, msg);
+
+            String response = future.get(LIST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            return parseFileListResponse(response);
+        } catch (TimeoutException e) {
+            throw new BusinessException(504, "File operation timed out");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("File operation failed: " + e.getMessage());
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public ResponseEntity<StreamingResponseBody> downloadFile(String agentId, String path) {
+        String requestId = UUID.randomUUID().toString();
+        BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+        downloadQueues.put(requestId, queue);
+
+        try {
+            Map<String, Object> msg = Map.of(
+                "type", "file_download",
+                "requestId", requestId,
+                "path", path
+            );
+            sendToAgent(agentId, msg);
+
+            String fileName = path.contains("/") ? path.substring(path.lastIndexOf('/') + 1) : path;
+            String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replace("+", "%20");
+
+            // Wait for the first chunk to get TotalSize for Content-Length header
+            String firstChunkJson = queue.poll(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (firstChunkJson == null) {
+                throw new BusinessException(504, "Download timed out waiting for first chunk");
+            }
+
+            JsonNode firstNode = objectMapper.readTree(firstChunkJson);
+            if (firstNode.has("success") && !firstNode.get("success").asBoolean()) {
+                String error = firstNode.has("error") ? firstNode.get("error").asText() : "Download failed";
+                throw new BusinessException(error);
+            }
+
+            long totalSize = firstNode.has("totalSize") ? firstNode.get("totalSize").asLong() : -1;
+
+            StreamingResponseBody responseBody = outputStream -> {
+                try {
+                    // Process first chunk that we already fetched
+                    String data = firstNode.has("data") ? firstNode.get("data").asText() : "";
+                    if (!data.isEmpty()) {
+                        byte[] decoded = Base64.getDecoder().decode(data);
+                        outputStream.write(decoded);
+                        outputStream.flush();
+                    }
+
+                    boolean isFinal = firstNode.has("final") && firstNode.get("final").asBoolean();
+                    if (isFinal) {
+                        return;
+                    }
+
+                    // Continue processing remaining chunks
+                    while (true) {
+                        String chunkJson = queue.poll(DOWNLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                        if (chunkJson == null) {
+                            throw new RuntimeException("Download timed out");
+                        }
+
+                        JsonNode node = objectMapper.readTree(chunkJson);
+
+                        // Check for error response
+                        if (node.has("success") && !node.get("success").asBoolean()) {
+                            String error = node.has("error") ? node.get("error").asText() : "Download failed";
+                            throw new RuntimeException(error);
+                        }
+
+                        String chunkData = node.has("data") ? node.get("data").asText() : "";
+                        if (!chunkData.isEmpty()) {
+                            byte[] decoded = Base64.getDecoder().decode(chunkData);
+                            outputStream.write(decoded);
+                            outputStream.flush();
+                        }
+
+                        boolean chunkFinal = node.has("final") && node.get("final").asBoolean();
+                        if (chunkFinal) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Download interrupted", e);
+                } finally {
+                    downloadQueues.remove(requestId);
+                }
+            };
+
+            var responseBuilder = ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"" + fileName + "\"; filename*=UTF-8''" + encodedFileName);
+
+            if (totalSize > 0) {
+                responseBuilder.header(HttpHeaders.CONTENT_LENGTH, String.valueOf(totalSize));
+            }
+
+            return responseBuilder.body(responseBody);
+        } catch (BusinessException e) {
+            downloadQueues.remove(requestId);
+            throw e;
+        } catch (InterruptedException e) {
+            downloadQueues.remove(requestId);
+            Thread.currentThread().interrupt();
+            throw new BusinessException("Download interrupted");
+        } catch (Exception e) {
+            downloadQueues.remove(requestId);
+            throw new BusinessException("Download failed: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void uploadFile(String agentId, String path, MultipartFile file) {
+        String requestId = UUID.randomUUID().toString();
+
+        try {
+            byte[] fileBytes = file.getBytes();
+
+            // Send upload start
+            CompletableFuture<String> startFuture = new CompletableFuture<>();
+            pendingRequests.put(requestId, startFuture);
+
+            String destPath = path.endsWith("/") ? path + file.getOriginalFilename() : path + "/" + file.getOriginalFilename();
+
+            Map<String, Object> startMsg = new HashMap<>();
+            startMsg.put("type", "file_upload_start");
+            startMsg.put("requestId", requestId);
+            startMsg.put("path", destPath);
+            startMsg.put("size", (long) fileBytes.length);
+            sendToAgent(agentId, startMsg);
+
+            // Wait for start acknowledgment
+            String startResponse = startFuture.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            pendingRequests.remove(requestId);
+            checkResponseSuccess(startResponse);
+
+            // Send chunks
+            int totalChunks = (int) Math.ceil((double) fileBytes.length / CHUNK_SIZE);
+            if (totalChunks == 0) totalChunks = 1; // empty file
+
+            for (int i = 0; i < totalChunks; i++) {
+                int retryCount = 0;
+                boolean chunkSent = false;
+
+                while (!chunkSent) {
+                    String chunkRequestId = requestId + "_chunk_" + i;
+                    CompletableFuture<String> chunkFuture = new CompletableFuture<>();
+                    pendingRequests.put(chunkRequestId, chunkFuture);
+
+                    try {
+                        int start = i * CHUNK_SIZE;
+                        int end = Math.min(start + CHUNK_SIZE, fileBytes.length);
+                        byte[] chunk = Arrays.copyOfRange(fileBytes, start, end);
+                        String base64Data = Base64.getEncoder().encodeToString(chunk);
+
+                        Map<String, Object> chunkMsg = new HashMap<>();
+                        chunkMsg.put("type", "file_upload_chunk");
+                        chunkMsg.put("requestId", requestId);
+                        chunkMsg.put("index", i);
+                        chunkMsg.put("data", base64Data);
+                        chunkMsg.put("final", i == totalChunks - 1);
+                        sendToAgent(agentId, chunkMsg);
+
+                        // Only wait for the final chunk acknowledgment
+                        if (i == totalChunks - 1) {
+                            String chunkResponse = chunkFuture.get(UPLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                            checkResponseSuccess(chunkResponse);
+                        }
+                        chunkSent = true;
+                    } catch (TimeoutException e) {
+                        retryCount++;
+                        log.warn("Upload chunk {} timed out (attempt {}/{})", i, retryCount, MAX_CHUNK_RETRIES);
+                        if (retryCount >= MAX_CHUNK_RETRIES) {
+                            throw e;
+                        }
+                    } catch (BusinessException e) {
+                        retryCount++;
+                        log.warn("Upload chunk {} failed: {} (attempt {}/{})", i, e.getMessage(), retryCount, MAX_CHUNK_RETRIES);
+                        if (retryCount >= MAX_CHUNK_RETRIES) {
+                            throw e;
+                        }
+                    } finally {
+                        pendingRequests.remove(chunkRequestId);
+                    }
+                }
+            }
+        } catch (TimeoutException e) {
+            throw new BusinessException(504, "Upload timed out");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("Upload failed: " + e.getMessage());
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public void mkdir(String agentId, String path) {
+        simpleFileOperation(agentId, "file_mkdir", path, OPERATION_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public void delete(String agentId, String path) {
+        simpleFileOperation(agentId, "file_delete", path, OPERATION_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    public void rename(String agentId, String oldPath, String newPath) {
+        String requestId = UUID.randomUUID().toString();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingRequests.put(requestId, future);
+
+        try {
+            Map<String, Object> msg = new HashMap<>();
+            msg.put("type", "file_rename");
+            msg.put("requestId", requestId);
+            msg.put("oldPath", oldPath);
+            msg.put("newPath", newPath);
+            sendToAgent(agentId, msg);
+
+            String response = future.get(OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            checkResponseSuccess(response);
+        } catch (TimeoutException e) {
+            throw new BusinessException(504, "File operation timed out");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("File operation failed: " + e.getMessage());
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public void handleFileResponse(String requestId, String responseJson) {
+        // First check download queues (for streaming chunks)
+        BlockingQueue<String> downloadQueue = downloadQueues.get(requestId);
+        if (downloadQueue != null) {
+            downloadQueue.offer(responseJson);
+            return;
+        }
+
+        // Then check pending futures
+        CompletableFuture<String> future = pendingRequests.get(requestId);
+        if (future != null) {
+            future.complete(responseJson);
+            return;
+        }
+
+        // Check chunk-specific futures for uploads
+        // Upload chunks use requestId + "_chunk_" + index
+        // The agent sends back the original requestId, so we need to find matching chunk futures
+        for (Map.Entry<String, CompletableFuture<String>> entry : pendingRequests.entrySet()) {
+            if (entry.getKey().startsWith(requestId + "_chunk_")) {
+                entry.getValue().complete(responseJson);
+                return;
+            }
+        }
+
+        log.warn("No pending request found for requestId: {}", requestId);
+    }
+
+    // --- Private helpers ---
+
+    private void simpleFileOperation(String agentId, String type, String path, long timeoutSeconds) {
+        String requestId = UUID.randomUUID().toString();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingRequests.put(requestId, future);
+
+        try {
+            Map<String, Object> msg = Map.of(
+                "type", type,
+                "requestId", requestId,
+                "path", path
+            );
+            sendToAgent(agentId, msg);
+
+            String response = future.get(timeoutSeconds, TimeUnit.SECONDS);
+            checkResponseSuccess(response);
+        } catch (TimeoutException e) {
+            throw new BusinessException(504, "File operation timed out");
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("File operation failed: " + e.getMessage());
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    private void sendToAgent(String agentId, Map<String, Object> message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            boolean sent = agentHandler.sendToAgent(agentId, json);
+            if (!sent) {
+                throw new BusinessException(400, "Agent not connected");
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (JsonProcessingException e) {
+            throw new BusinessException("Failed to serialize message: " + e.getMessage());
+        }
+    }
+
+    private void checkResponseSuccess(String responseJson) {
+        try {
+            JsonNode node = objectMapper.readTree(responseJson);
+            if (node.has("success") && !node.get("success").asBoolean()) {
+                String error = node.has("error") ? node.get("error").asText() : "Operation failed";
+                if (error.contains("access denied") || error.contains("path traversal") ||
+                    error.contains("symlink") || error.contains("read-only")) {
+                    throw new BusinessException(403, "Access denied");
+                }
+                throw new BusinessException("File operation failed: " + error);
+            }
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("Failed to parse agent response: " + e.getMessage());
+        }
+    }
+
+    private List<FileInfoVO> parseFileListResponse(String responseJson) {
+        try {
+            JsonNode node = objectMapper.readTree(responseJson);
+            if (node.has("success") && !node.get("success").asBoolean()) {
+                String error = node.has("error") ? node.get("error").asText() : "List failed";
+                if (error.contains("access denied") || error.contains("path traversal") ||
+                    error.contains("symlink")) {
+                    throw new BusinessException(403, "Access denied");
+                }
+                throw new BusinessException("File operation failed: " + error);
+            }
+
+            List<FileInfoVO> files = new ArrayList<>();
+            if (node.has("entries") && node.get("entries").isArray()) {
+                for (JsonNode entry : node.get("entries")) {
+                    files.add(FileInfoVO.builder()
+                        .name(entry.get("name").asText())
+                        .dir(entry.has("isDir") && entry.get("isDir").asBoolean())
+                        .size(entry.has("size") ? entry.get("size").asLong() : 0)
+                        .mode(entry.has("mode") ? entry.get("mode").asText() : "")
+                        .modTime(entry.has("modTime") ? entry.get("modTime").asLong() : 0)
+                        .build());
+                }
+            }
+            return files;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException("Failed to parse file list response: " + e.getMessage());
+        }
+    }
+}

--- a/easyshell-server/src/main/java/com/easyshell/server/websocket/AgentWebSocketHandler.java
+++ b/easyshell-server/src/main/java/com/easyshell/server/websocket/AgentWebSocketHandler.java
@@ -13,6 +13,9 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+import com.easyshell.server.service.FileProxyService;
+
+import java.time.LocalDateTime;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,8 +31,9 @@ public class AgentWebSocketHandler extends TextWebSocketHandler {
     private final JobRepository jobRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final Map<String, WebSocketSession> agentSessions = new ConcurrentHashMap<>();
+private final Map<String, WebSocketSession> agentSessions = new ConcurrentHashMap<>();
     private TerminalWebSocketHandler terminalHandler;
+    private FileProxyService fileProxyService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
@@ -83,14 +87,20 @@ public class AgentWebSocketHandler extends TextWebSocketHandler {
                         terminalHandler.handleAgentReady(sessionId);
                     }
                 }
-                case "terminal_error" -> {
-                    String sessionId = node.has("sessionId") ? node.get("sessionId").asText() : "";
-                    String data = node.has("data") ? node.get("data").asText() : "";
-                    if (terminalHandler != null) {
-                        terminalHandler.handleAgentError(sessionId, data);
+case "terminal_error" -> {
+String sessionId = node.has("sessionId") ? node.get("sessionId").asText() : "";
+String data = node.has("data") ? node.get("data").asText() : "";
+if (terminalHandler != null) {
+terminalHandler.handleAgentError(sessionId, data);
+}
+                }
+                case "file_list_result", "file_download_chunk", "file_result" -> {
+                    String requestId = node.has("requestId") ? node.get("requestId").asText() : "";
+                    if (fileProxyService != null && !requestId.isEmpty()) {
+                        fileProxyService.handleFileResponse(requestId, message.getPayload());
                     }
                 }
-                default -> log.warn("Unknown message type from agent: {}", type);
+default -> log.warn("Unknown message type from agent: {}", type);
             }
         } catch (Exception e) {
             log.error("Error processing agent message", e);
@@ -150,6 +160,10 @@ public class AgentWebSocketHandler extends TextWebSocketHandler {
 
     public void setTerminalHandler(TerminalWebSocketHandler handler) {
         this.terminalHandler = handler;
+    }
+
+    public void setFileProxyService(FileProxyService service) {
+        this.fileProxyService = service;
     }
 
     private String extractAgentId(WebSocketSession session) {

--- a/easyshell-server/src/main/resources/application.yml
+++ b/easyshell-server/src/main/resources/application.yml
@@ -4,9 +4,13 @@ server:
     context-path: /
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 510MB
   mvc:
     async:
-      request-timeout: 300000
+      request-timeout: -1
   application:
     name: easyshell-server
 

--- a/easyshell-web/nginx.conf
+++ b/easyshell-web/nginx.conf
@@ -7,20 +7,38 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # File upload size limit (for file manager)
+    client_max_body_size 500M;
+
     set $backend http://easyshell-server:18080;
 
     location / {
         try_files $uri $uri/ /index.html;
     }
 
+    # File transfer endpoints — no timeout, no buffering
+    location ~ ^/api/v1/.*/files {
+        proxy_pass $backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        client_max_body_size 500M;
+    }
+
+    # Regular API endpoints
     location /api/ {
         proxy_pass $backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 300s;
-        proxy_send_timeout 300s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
     }
 
     location /ws/ {

--- a/easyshell-web/package-lock.json
+++ b/easyshell-web/package-lock.json
@@ -12,6 +12,7 @@
         "@ant-design/icons": "^6.1.0",
         "@ant-design/pro-components": "^3.1.4-0",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.10.0",
@@ -3754,6 +3755,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/easyshell-web/package.json
+++ b/easyshell-web/package.json
@@ -14,6 +14,7 @@
     "@ant-design/icons": "^6.1.0",
     "@ant-design/pro-components": "^3.1.4-0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.0",

--- a/easyshell-web/src/api/request.ts
+++ b/easyshell-web/src/api/request.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const request = axios.create({
   baseURL: '/api',
-  timeout: 10000,
+  timeout: 30000,
 });
 
 request.interceptors.request.use(

--- a/easyshell-web/src/i18n/locales/en-US.json
+++ b/easyshell-web/src/i18n/locales/en-US.json
@@ -853,6 +853,7 @@
     "disk": "Disk",
     "totalMemory": "Total Memory",
     "agentVersion": "Agent Version",
+    "agentOutdated": "Agent outdated ({{current}}). Please reinstall to update to {{latest}}",
     "lastHeartbeat": "Last Heartbeat",
     "addServer": "Add Server",
     "deployHistory": "Deploy History",
@@ -1041,7 +1042,48 @@
     "disconnectedRefresh": "Disconnected, please refresh to retry",
     "error": "Error",
     "system": "[System]",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "toolbar": {
+      "files": "Files",
+      "search": "Search",
+      "newTab": "New Tab",
+      "fullscreen": "Fullscreen",
+      "exitFullscreen": "Exit Fullscreen",
+      "settings": "Settings",
+      "copy": "Copy",
+      "paste": "Paste"
+    },
+    "tabs": {
+      "maxReached": "Maximum {{max}} tabs allowed",
+      "defaultName": "Terminal {{index}}"
+    },
+    "search": {
+      "placeholder": "Search...",
+      "caseSensitive": "Case Sensitive",
+      "regex": "Regex",
+      "noResults": "No results found"
+    },
+    "files": {
+      "title": "File Manager",
+      "upload": "Upload",
+      "download": "Download",
+      "newFolder": "New Folder",
+      "delete": "Delete",
+      "rename": "Rename",
+      "refresh": "Refresh",
+      "deleteConfirm": "Are you sure you want to delete \"{{name}}\"?",
+      "uploadSuccess": "File uploaded successfully",
+      "downloadStarted": "Download started",
+      "downloadSuccess": "Download completed",
+      "uploading": "Uploading...",
+      "transferring": "Transferring to target server...",
+      "operationFailed": "Operation failed: {{error}}",
+      "pathPlaceholder": "Enter path...",
+      "newFolderName": "New Folder Name",
+      "emptyDirectory": "Empty directory",
+      "fileTooLarge": "File size exceeds the maximum limit ({{max}}MB)",
+      "goUp": "Go Up"
+    }
   },
   "status": {
     "task": {

--- a/easyshell-web/src/i18n/locales/zh-CN.json
+++ b/easyshell-web/src/i18n/locales/zh-CN.json
@@ -853,6 +853,7 @@
     "disk": "磁盘",
     "totalMemory": "总内存",
     "agentVersion": "Agent 版本",
+    "agentOutdated": "Agent 版本过旧 ({{current}})，请重装以更新到 {{latest}}",
     "lastHeartbeat": "最后心跳",
     "addServer": "添加服务器",
     "deployHistory": "部署历史",
@@ -1041,7 +1042,48 @@
     "disconnectedRefresh": "连接已断开，请刷新重试",
     "error": "错误",
     "system": "[系统]",
-    "unknownError": "未知错误"
+    "unknownError": "未知错误",
+    "toolbar": {
+      "files": "文件",
+      "search": "搜索",
+      "newTab": "新标签",
+      "fullscreen": "全屏",
+      "exitFullscreen": "退出全屏",
+      "settings": "设置",
+      "copy": "复制",
+      "paste": "粘贴"
+    },
+    "tabs": {
+      "maxReached": "最多允许 {{max}} 个标签",
+      "defaultName": "终端 {{index}}"
+    },
+    "search": {
+      "placeholder": "搜索...",
+      "caseSensitive": "区分大小写",
+      "regex": "正则表达式",
+      "noResults": "未找到结果"
+    },
+    "files": {
+      "title": "文件管理",
+      "upload": "上传",
+      "download": "下载",
+      "newFolder": "新建文件夹",
+      "delete": "删除",
+      "rename": "重命名",
+      "refresh": "刷新",
+      "deleteConfirm": "确定要删除 \"{{name}}\" 吗？",
+      "uploadSuccess": "文件上传成功",
+      "downloadStarted": "下载已开始",
+      "downloadSuccess": "下载完成",
+      "uploading": "上传中...",
+      "transferring": "正在转存到目标服务器...",
+      "operationFailed": "操作失败：{{error}}",
+      "pathPlaceholder": "输入路径...",
+      "newFolderName": "新建文件夹名称",
+      "emptyDirectory": "空目录",
+      "fileTooLarge": "文件大小超过最大限制（{{max}}MB）",
+      "goUp": "返回上级"
+    }
   },
   "status": {
     "task": {

--- a/easyshell-web/src/pages/host/index.tsx
+++ b/easyshell-web/src/pages/host/index.tsx
@@ -10,7 +10,7 @@ import type { UploadFile } from 'antd';
 import {
   DesktopOutlined, EyeOutlined, CodeOutlined, DownloadOutlined,
   PlusOutlined, HistoryOutlined, ReloadOutlined, DeleteOutlined, DisconnectOutlined, SettingOutlined,
-  ImportOutlined, RocketOutlined, CloudUploadOutlined,
+  ImportOutlined, RocketOutlined, CloudUploadOutlined, WarningOutlined,
 } from '@ant-design/icons';
 import { ProTable } from '@ant-design/pro-components';
 import type { ProColumns, ActionType } from '@ant-design/pro-components';
@@ -27,6 +27,26 @@ import { formatBytes } from '../../utils/format';
 import type { TagVO, HostCredentialVO } from '../../types';
 
 const { Text } = Typography;
+
+/* ── Agent version checking ── */
+const LATEST_AGENT_VERSION = '0.2.2';
+
+function compareVersions(v1: string, v2: string): number {
+  const parts1 = v1.split('.').map(Number);
+  const parts2 = v2.split('.').map(Number);
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const p1 = parts1[i] || 0;
+    const p2 = parts2[i] || 0;
+    if (p1 < p2) return -1;
+    if (p1 > p2) return 1;
+  }
+  return 0;
+}
+
+function isAgentOutdated(version: string | undefined): boolean {
+  if (!version) return false;
+  return compareVersions(version, LATEST_AGENT_VERSION) < 0;
+}
 
 /* ── CSV Export Utility ── */
 function exportCSV(hosts: HostCredentialVO[], agentTags: Record<string, TagVO[]>, t: (key: string) => string) {
@@ -583,8 +603,22 @@ const Host: React.FC = () => {
       title: t('host.agentVersion'),
       dataIndex: 'agentVersion',
       key: 'agentVersion',
-      width: 110,
-      render: (_, record) => record.agentVersion || '-',
+      width: 130,
+      render: (_, record) => {
+        if (!record.agentVersion) return '-';
+        const outdated = isAgentOutdated(record.agentVersion);
+        if (outdated) {
+          return (
+            <Tooltip title={t('host.agentOutdated', { current: record.agentVersion, latest: LATEST_AGENT_VERSION })}>
+              <Space size={4}>
+                <Text type="warning">{record.agentVersion}</Text>
+                <WarningOutlined style={{ color: '#faad14' }} />
+              </Space>
+            </Tooltip>
+          );
+        }
+        return <Text type="success">{record.agentVersion}</Text>;
+      },
     },
     {
       title: t('host.lastHeartbeat'),

--- a/easyshell-web/src/pages/terminal/components/FileManager.tsx
+++ b/easyshell-web/src/pages/terminal/components/FileManager.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Input, Space, Tooltip, Typography, Upload, Modal, theme, Progress } from 'antd';
+import {
+  CloseOutlined,
+  UploadOutlined,
+  FolderAddOutlined,
+  ReloadOutlined,
+  ArrowUpOutlined
+} from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+import { useFileManager } from '../hooks/useFileManager';
+import { FileTree } from './FileTree';
+
+const { Text } = Typography;
+
+interface FileManagerProps {
+  agentId: string;
+  visible: boolean;
+  onClose: () => void;
+}
+
+const FileManager: React.FC<FileManagerProps> = ({ agentId, visible, onClose }) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [pathInput, setPathInput] = useState('/');
+  const [newFolderVisible, setNewFolderVisible] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+
+  const {
+    files,
+    currentPath,
+    loading,
+    uploadProgress,
+    uploadPhase,
+    downloadProgress,
+    navigate,
+    upload,
+    download,
+    mkdir,
+    remove,
+    rename,
+    refresh,
+    goUp
+  } = useFileManager(agentId);
+
+  useEffect(() => {
+    if (visible && agentId) {
+      navigate('/');
+    }
+  }, [visible, agentId, navigate]);
+
+  useEffect(() => {
+    setPathInput(currentPath);
+  }, [currentPath]);
+
+  const handlePathSubmit = () => {
+    if (pathInput && pathInput !== currentPath) {
+      navigate(pathInput);
+    }
+  };
+
+  const handleNewFolder = () => {
+    if (newFolderName) {
+      mkdir(newFolderName);
+      setNewFolderVisible(false);
+      setNewFolderName('');
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div style={{
+      width: 360,
+      borderLeft: `1px solid ${token.colorBorderSecondary}`,
+      background: token.colorBgContainer,
+      borderRadius: '0 12px 12px 0',
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      overflow: 'hidden'
+    }}>
+      {/* Header */}
+      <div style={{
+        padding: '12px 16px',
+        borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+      }}>
+        <Text strong>{t('terminal.files.title')}</Text>
+        <Button type="text" size="small" icon={<CloseOutlined />} onClick={onClose} />
+      </div>
+
+      {/* Toolbar & Path */}
+      <div style={{ padding: '8px 12px', borderBottom: `1px solid ${token.colorBorderSecondary}` }}>
+        <Space style={{ width: '100%', marginBottom: 8, justifyContent: 'space-between' }}>
+          <Space>
+            <Tooltip title={t('terminal.files.goUp')}>
+              <Button size="small" icon={<ArrowUpOutlined />} onClick={goUp} disabled={currentPath === '/'} />
+            </Tooltip>
+            <Tooltip title={t('terminal.files.refresh')}>
+              <Button size="small" icon={<ReloadOutlined />} onClick={refresh} loading={loading} />
+            </Tooltip>
+          </Space>
+          <Space>
+            <Tooltip title={t('terminal.files.newFolder')}>
+              <Button size="small" icon={<FolderAddOutlined />} onClick={() => setNewFolderVisible(true)} />
+            </Tooltip>
+            <Upload
+              customRequest={({ file }) => upload(file as File)}
+              showUploadList={false}
+            >
+              <Tooltip title={t('terminal.files.upload')}>
+                <Button size="small" icon={<UploadOutlined />} />
+              </Tooltip>
+            </Upload>
+          </Space>
+        </Space>
+        
+        <Input
+          size="small"
+          value={pathInput}
+          onChange={e => setPathInput(e.target.value)}
+          onPressEnter={handlePathSubmit}
+          placeholder={t('terminal.files.pathPlaceholder')}
+        />
+      </div>
+
+      {/* Upload Progress */}
+      {uploadProgress !== null && (
+        <div style={{ padding: '8px 12px', borderBottom: `1px solid ${token.colorBorderSecondary}` }}>
+          <Progress
+            percent={uploadProgress}
+            size="small"
+            status={uploadPhase === 'transferring' ? 'active' : 'active'}
+            strokeColor={uploadPhase === 'transferring' ? '#faad14' : undefined}
+            format={(percent) =>
+              uploadPhase === 'transferring'
+                ? t('terminal.files.transferring', 'Transferring to target server...')
+                : `${t('terminal.files.upload', 'Upload')} ${percent}%`
+            }
+          />
+        </div>
+      )}
+
+      {/* Download Progress */}
+      {downloadProgress !== null && (
+        <div style={{ padding: '8px 12px', borderBottom: `1px solid ${token.colorBorderSecondary}` }}>
+          <Progress percent={downloadProgress} size="small" status="active" strokeColor="#52c41a" format={(percent) => `${t('terminal.files.download', 'Download')} ${percent}%`} />
+        </div>
+      )}
+
+      {/* File List */}
+      <FileTree
+        files={files}
+        loading={loading}
+        currentPath={currentPath}
+        onNavigate={navigate}
+        onDownload={download}
+        onDelete={remove}
+        onRename={rename}
+      />
+
+      {/* New Folder Modal */}
+      <Modal
+        title={t('terminal.files.newFolder')}
+        open={newFolderVisible}
+        onOk={handleNewFolder}
+        onCancel={() => {
+          setNewFolderVisible(false);
+          setNewFolderName('');
+        }}
+        width={300}
+        okText={t('common.confirm')}
+        cancelText={t('common.cancel')}
+      >
+        <Input
+          autoFocus
+          value={newFolderName}
+          onChange={e => setNewFolderName(e.target.value)}
+          onPressEnter={handleNewFolder}
+          placeholder={t('terminal.files.newFolderName')}
+        />
+      </Modal>
+    </div>
+  );
+};
+
+export default FileManager;

--- a/easyshell-web/src/pages/terminal/components/FileTree.tsx
+++ b/easyshell-web/src/pages/terminal/components/FileTree.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { List, Button, Space, Typography, Tooltip, Input, Modal } from 'antd';
+import {
+  FolderOutlined,
+  FileOutlined,
+  DownloadOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  CheckOutlined,
+  CloseOutlined
+} from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+import type { FileInfo } from '../hooks/useFileManager';
+
+const { Text } = Typography;
+
+interface FileTreeProps {
+  files: FileInfo[];
+  loading: boolean;
+  currentPath: string;
+  onNavigate: (path: string) => void;
+  onDownload: (path: string, fileName: string) => void;
+  onDelete: (path: string) => void;
+  onRename: (oldPath: string, newPath: string) => void;
+}
+
+export const FileTree: React.FC<FileTreeProps> = ({
+  files,
+  loading,
+  currentPath,
+  onNavigate,
+  onDownload,
+  onDelete,
+  onRename,
+}) => {
+  const { t } = useTranslation();
+  const [editingFile, setEditingFile] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+
+  const formatSize = (bytes: number) => {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  const getFullPath = (fileName: string) => {
+    return currentPath.endsWith('/') ? `${currentPath}${fileName}` : `${currentPath}/${fileName}`;
+  };
+
+  const sortedFiles = [...files].sort((a, b) => {
+    if (a.isDir && !b.isDir) return -1;
+    if (!a.isDir && b.isDir) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  const handleDelete = (file: FileInfo) => {
+    Modal.confirm({
+      title: t('terminal.files.delete'),
+      content: t('terminal.files.deleteConfirm', { name: file.name }),
+      okText: t('common.confirm'),
+      cancelText: t('common.cancel'),
+      okButtonProps: { danger: true },
+      onOk: () => onDelete(getFullPath(file.name)),
+    });
+  };
+
+  const startEdit = (file: FileInfo) => {
+    setEditingFile(file.name);
+    setEditName(file.name);
+  };
+
+  const submitEdit = (oldName: string) => {
+    if (editName && editName !== oldName) {
+      const oldPath = getFullPath(oldName);
+      const newPath = getFullPath(editName);
+      onRename(oldPath, newPath);
+    }
+    setEditingFile(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingFile(null);
+    setEditName('');
+  };
+
+  return (
+    <List
+      loading={loading}
+      dataSource={sortedFiles}
+      size="small"
+      style={{ overflow: 'auto', flex: 1 }}
+      renderItem={(item) => {
+        const isEditing = editingFile === item.name;
+
+        return (
+          <List.Item
+            key={item.name}
+            style={{ padding: '8px 12px' }}
+            actions={
+              isEditing ? [
+                <Button key="save" type="text" size="small" icon={<CheckOutlined />} onClick={() => submitEdit(item.name)} style={{ color: '#52c41a' }} />,
+                <Button key="cancel" type="text" size="small" icon={<CloseOutlined />} onClick={cancelEdit} />
+              ] : [
+                !item.isDir && (
+                  <Tooltip key="download" title={t('terminal.files.download')}>
+                    <Button type="text" size="small" icon={<DownloadOutlined />} onClick={() => onDownload(getFullPath(item.name), item.name)} />
+                  </Tooltip>
+                ),
+                <Tooltip key="rename" title={t('terminal.files.rename')}>
+                  <Button type="text" size="small" icon={<EditOutlined />} onClick={() => startEdit(item)} />
+                </Tooltip>,
+                <Tooltip key="delete" title={t('terminal.files.delete')}>
+                  <Button type="text" danger size="small" icon={<DeleteOutlined />} onClick={() => handleDelete(item)} />
+                </Tooltip>
+              ].filter(Boolean) as React.ReactNode[]
+            }
+          >
+            <List.Item.Meta
+              avatar={item.isDir ? <FolderOutlined style={{ color: '#1890ff', fontSize: 18 }} /> : <FileOutlined style={{ fontSize: 18, color: '#8c8c8c' }} />}
+              title={
+                isEditing ? (
+                  <Input
+                    size="small"
+                    value={editName}
+                    onChange={e => setEditName(e.target.value)}
+                    onPressEnter={() => submitEdit(item.name)}
+                    onBlur={cancelEdit}
+                    autoFocus
+                  />
+                ) : (
+                  <Text
+                    style={{ cursor: item.isDir ? 'pointer' : 'default', color: item.isDir ? '#1890ff' : 'inherit' }}
+                    onClick={() => item.isDir && onNavigate(getFullPath(item.name))}
+                    ellipsis={{ tooltip: item.name }}
+                  >
+                    {item.name}
+                  </Text>
+                )
+              }
+              description={
+                <Space size="small" style={{ fontSize: 12, color: '#8c8c8c' }}>
+                  <span>{!item.isDir ? formatSize(item.size) : '--'}</span>
+                  <span>{new Date(item.modTime * 1000).toLocaleString()}</span>
+                  <span>{item.mode}</span>
+                </Space>
+              }
+              style={{ margin: 0 }}
+            />
+          </List.Item>
+        );
+      }}
+    />
+  );
+};

--- a/easyshell-web/src/pages/terminal/components/SearchBar.tsx
+++ b/easyshell-web/src/pages/terminal/components/SearchBar.tsx
@@ -1,0 +1,126 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Input, Button, Checkbox, Space, theme } from 'antd';
+import type { InputRef } from 'antd';
+import {
+  CloseOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+} from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+import type { SearchAddon } from '@xterm/addon-search';
+
+interface SearchBarProps {
+  searchAddon: SearchAddon | null;
+  visible: boolean;
+  onClose: () => void;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ searchAddon, visible, onClose }) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const inputRef = useRef<InputRef>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [regex, setRegex] = useState(false);
+
+  useEffect(() => {
+    if (visible && inputRef.current) {
+      inputRef.current?.focus();
+    }
+  }, [visible]);
+
+  const searchOptions = { caseSensitive, regex };
+
+  const findNext = useCallback(() => {
+    if (searchAddon && searchTerm) {
+      searchAddon.findNext(searchTerm, searchOptions);
+    }
+  }, [searchAddon, searchTerm, searchOptions]);
+
+  const findPrevious = useCallback(() => {
+    if (searchAddon && searchTerm) {
+      searchAddon.findPrevious(searchTerm, searchOptions);
+    }
+  }, [searchAddon, searchTerm, searchOptions]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    } else if (e.key === 'Enter') {
+      if (e.shiftKey) {
+        findPrevious();
+      } else {
+        findNext();
+      }
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 8,
+        right: 16,
+        zIndex: 10,
+        background: token.colorBgElevated,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 8,
+        padding: '8px 12px',
+        boxShadow: token.boxShadowSecondary,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}
+    >
+      <Input
+        ref={inputRef}
+        size="small"
+        placeholder={t('terminal.search.placeholder')}
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        onKeyDown={handleKeyDown}
+        style={{ width: 180 }}
+      />
+      <Space size={4}>
+        <Button
+          type="text"
+          size="small"
+          icon={<ArrowUpOutlined />}
+          onClick={findPrevious}
+          disabled={!searchTerm}
+        />
+        <Button
+          type="text"
+          size="small"
+          icon={<ArrowDownOutlined />}
+          onClick={findNext}
+          disabled={!searchTerm}
+        />
+      </Space>
+      <Checkbox
+        checked={caseSensitive}
+        onChange={(e) => setCaseSensitive(e.target.checked)}
+        style={{ fontSize: 12 }}
+      >
+        {t('terminal.search.caseSensitive')}
+      </Checkbox>
+      <Checkbox
+        checked={regex}
+        onChange={(e) => setRegex(e.target.checked)}
+        style={{ fontSize: 12 }}
+      >
+        {t('terminal.search.regex')}
+      </Checkbox>
+      <Button
+        type="text"
+        size="small"
+        icon={<CloseOutlined />}
+        onClick={onClose}
+      />
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/easyshell-web/src/pages/terminal/components/TerminalInstance.tsx
+++ b/easyshell-web/src/pages/terminal/components/TerminalInstance.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useImperativeHandle, forwardRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { SearchAddon } from '@xterm/addon-search';
+import '@xterm/xterm/css/xterm.css';
+import type { ConnectionStatus } from '../types';
+import { terminalTheme } from '../types';
+
+interface TerminalInstanceProps {
+  tabId: string;
+  agentId: string;
+  isActive: boolean;
+  onStatusChange: (tabId: string, status: ConnectionStatus) => void;
+}
+
+export interface TerminalInstanceRef {
+  searchAddon: SearchAddon | null;
+  copySelection: () => void;
+  pasteFromClipboard: () => void;
+  focus: () => void;
+}
+
+const TerminalInstance = forwardRef<TerminalInstanceRef, TerminalInstanceProps>(
+  ({ tabId, agentId, isActive, onStatusChange }, ref) => {
+    const { t } = useTranslation();
+    const containerRef = useRef<HTMLDivElement>(null);
+    const termRef = useRef<Terminal | null>(null);
+    const wsRef = useRef<WebSocket | null>(null);
+    const fitAddonRef = useRef<FitAddon | null>(null);
+    const searchAddonRef = useRef<SearchAddon | null>(null);
+
+    const copySelection = useCallback(() => {
+      if (termRef.current) {
+        const selection = termRef.current.getSelection();
+        if (selection) {
+          navigator.clipboard.writeText(selection);
+        }
+      }
+    }, []);
+
+    const pasteFromClipboard = useCallback(() => {
+      navigator.clipboard.readText().then((text) => {
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify({ type: 'input', data: text }));
+        }
+      });
+    }, []);
+
+    const focus = useCallback(() => {
+      termRef.current?.focus();
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      searchAddon: searchAddonRef.current,
+      copySelection,
+      pasteFromClipboard,
+      focus,
+    }), [copySelection, pasteFromClipboard, focus]);
+
+    useEffect(() => {
+      if (!containerRef.current || !agentId) return;
+
+      const term = new Terminal({
+        cursorBlink: true,
+        fontSize: 14,
+        fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, monospace",
+        theme: terminalTheme,
+        allowProposedApi: true,
+        scrollback: 5000,
+        convertEol: true,
+      });
+
+      const fitAddon = new FitAddon();
+      const webLinksAddon = new WebLinksAddon();
+      const searchAddon = new SearchAddon();
+
+      term.loadAddon(fitAddon);
+      term.loadAddon(webLinksAddon);
+      term.loadAddon(searchAddon);
+      term.open(containerRef.current);
+
+      termRef.current = term;
+      fitAddonRef.current = fitAddon;
+      searchAddonRef.current = searchAddon;
+
+      setTimeout(() => fitAddon.fit(), 100);
+
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const wsUrl = `${protocol}//${window.location.host}/ws/terminal/${agentId}`;
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      onStatusChange(tabId, 'connecting');
+      term.writeln('\x1b[36m' + t('terminal.system') + '\x1b[0m ' + t('terminal.connectingHost'));
+
+      ws.onopen = () => {
+        term.writeln('\x1b[36m' + t('terminal.system') + '\x1b[0m ' + t('terminal.wsConnected'));
+      };
+
+      ws.onmessage = (event: MessageEvent) => {
+        try {
+          const msg = JSON.parse(event.data as string) as { type: string; data?: string };
+          switch (msg.type) {
+            case 'terminal_ready':
+              onStatusChange(tabId, 'connected');
+              setTimeout(() => {
+                fitAddon.fit();
+                ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+              }, 200);
+              break;
+            case 'output':
+              if (msg.data) {
+                term.write(msg.data);
+              }
+              break;
+            case 'error':
+            case 'terminal_error':
+              term.writeln(`\x1b[31m[${t('terminal.error')}]\x1b[0m ${msg.data || t('terminal.unknownError')}`);
+              break;
+          }
+        } catch {
+          term.write(event.data as string);
+        }
+      };
+
+      ws.onclose = () => {
+        onStatusChange(tabId, 'disconnected');
+        term.writeln('\r\n\x1b[33m' + t('terminal.system') + '\x1b[0m ' + t('terminal.disconnectedRefresh'));
+      };
+
+      ws.onerror = () => {
+        onStatusChange(tabId, 'disconnected');
+        term.writeln('\r\n\x1b[31m' + t('terminal.system') + '\x1b[0m ' + t('terminal.connectionError'));
+      };
+
+      const inputDisposable = term.onData((data: string) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'input', data }));
+        }
+      });
+
+      const resizeDisposable = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+        }
+      });
+
+      const handleResize = () => {
+        if (fitAddonRef.current) {
+          fitAddonRef.current.fit();
+        }
+      };
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+        window.removeEventListener('resize', handleResize);
+        inputDisposable.dispose();
+        resizeDisposable.dispose();
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+        term.dispose();
+        termRef.current = null;
+        wsRef.current = null;
+        fitAddonRef.current = null;
+        searchAddonRef.current = null;
+      };
+    }, [agentId, tabId]);
+
+    // Refit when tab becomes active
+    useEffect(() => {
+      if (isActive && fitAddonRef.current) {
+        setTimeout(() => {
+          fitAddonRef.current?.fit();
+          termRef.current?.focus();
+        }, 50);
+      }
+    }, [isActive]);
+
+    return (
+      <div
+        ref={containerRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          padding: 8,
+          display: isActive ? 'block' : 'none',
+        }}
+      />
+    );
+  }
+);
+
+TerminalInstance.displayName = 'TerminalInstance';
+
+export default TerminalInstance;

--- a/easyshell-web/src/pages/terminal/components/TerminalTabs.tsx
+++ b/easyshell-web/src/pages/terminal/components/TerminalTabs.tsx
@@ -1,0 +1,144 @@
+import { useState, useRef, useEffect } from 'react';
+import { Tabs, Input, Tooltip } from 'antd';
+import type { InputRef } from 'antd';
+import { useTranslation } from 'react-i18next';
+import type { TerminalTab } from '../types';
+import { MAX_TABS, statusConfig } from '../types';
+
+interface TerminalTabsProps {
+  tabs: TerminalTab[];
+  activeTabId: string;
+  onTabChange: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+  onTabAdd: () => void;
+  onTabRename: (tabId: string, newLabel: string) => void;
+}
+
+const TerminalTabs: React.FC<TerminalTabsProps> = ({
+  tabs,
+  activeTabId,
+  onTabChange,
+  onTabClose,
+  onTabAdd,
+  onTabRename,
+}) => {
+  const { t } = useTranslation();
+  const [editingTabId, setEditingTabId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<InputRef>(null);
+
+  useEffect(() => {
+    if (editingTabId && inputRef.current) {
+      inputRef.current?.focus();
+    }
+  }, [editingTabId]);
+
+  const handleDoubleClick = (tabId: string, currentLabel: string) => {
+    setEditingTabId(tabId);
+    setEditValue(currentLabel);
+  };
+
+  const handleEditConfirm = () => {
+    if (editingTabId && editValue.trim()) {
+      onTabRename(editingTabId, editValue.trim());
+    }
+    setEditingTabId(null);
+    setEditValue('');
+  };
+
+  const handleEditCancel = () => {
+    setEditingTabId(null);
+    setEditValue('');
+  };
+
+  const tabItems = tabs.map((tab) => {
+    const statusColor = statusConfig[tab.status].color;
+    const label = editingTabId === tab.id ? (
+      <Input
+        ref={inputRef}
+        size="small"
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onPressEnter={handleEditConfirm}
+        onBlur={handleEditConfirm}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') handleEditCancel();
+        }}
+        style={{ width: 100, height: 22 }}
+        onClick={(e) => e.stopPropagation()}
+      />
+    ) : (
+      <span
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          handleDoubleClick(tab.id, tab.label);
+        }}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            backgroundColor: statusColor,
+            display: 'inline-block',
+            flexShrink: 0,
+          }}
+        />
+        {tab.label}
+      </span>
+    );
+
+    return {
+      key: tab.id,
+      label,
+      closable: tabs.length > 1,
+    };
+  });
+
+  const isMaxReached = tabs.length >= MAX_TABS;
+
+  const onEdit = (
+    targetKey: string | React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+    action: 'add' | 'remove',
+  ) => {
+    if (action === 'add') {
+      if (!isMaxReached) onTabAdd();
+    } else {
+      onTabClose(targetKey as string);
+    }
+  };
+
+  return (
+    <div style={{ marginBottom: 0 }}>
+      {isMaxReached ? (
+        <Tooltip title={t('terminal.tabs.maxReached', { max: MAX_TABS })}>
+          <div>
+            <Tabs
+              type="editable-card"
+              activeKey={activeTabId}
+              onChange={onTabChange}
+              onEdit={onEdit}
+              items={tabItems}
+              size="small"
+              hideAdd={isMaxReached}
+              style={{ marginBottom: 0 }}
+            />
+          </div>
+        </Tooltip>
+      ) : (
+        <Tabs
+          type="editable-card"
+          activeKey={activeTabId}
+          onChange={onTabChange}
+          onEdit={onEdit}
+          items={tabItems}
+          size="small"
+          style={{ marginBottom: 0 }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TerminalTabs;

--- a/easyshell-web/src/pages/terminal/components/TerminalToolbar.tsx
+++ b/easyshell-web/src/pages/terminal/components/TerminalToolbar.tsx
@@ -1,0 +1,109 @@
+import { Button, Space, Tooltip } from 'antd';
+import {
+  SearchOutlined,
+  PlusOutlined,
+  FullscreenOutlined,
+  FullscreenExitOutlined,
+  CopyOutlined,
+  SnippetsOutlined,
+  FolderOutlined,
+} from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+import { MAX_TABS } from '../types';
+
+interface TerminalToolbarProps {
+  onToggleFiles: () => void;
+  onSearch: () => void;
+  onAddTab: () => void;
+  onToggleFullscreen: () => void;
+  onCopy: () => void;
+  onPaste: () => void;
+  isFullscreen: boolean;
+  isFileManagerOpen: boolean;
+  tabCount: number;
+}
+
+const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
+  onToggleFiles,
+  onSearch,
+  onAddTab,
+  onToggleFullscreen,
+  onCopy,
+  onPaste,
+  isFullscreen,
+  isFileManagerOpen,
+  tabCount,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4, gap: 4 }}>
+      <Space size={4}>
+        <Tooltip title={t('terminal.toolbar.files')}>
+          <Button
+            type={isFileManagerOpen ? 'default' : 'text'}
+            size="small"
+            icon={<FolderOutlined />}
+            onClick={onToggleFiles}
+            disabled={false}
+          />
+        </Tooltip>
+        <Tooltip title={t('terminal.toolbar.search')}>
+          <Button
+            type="text"
+            size="small"
+            icon={<SearchOutlined />}
+            onClick={onSearch}
+          />
+        </Tooltip>
+        <Tooltip title={t('terminal.toolbar.copy')}>
+          <Button
+            type="text"
+            size="small"
+            icon={<CopyOutlined />}
+            onClick={onCopy}
+          />
+        </Tooltip>
+        <Tooltip title={t('terminal.toolbar.paste')}>
+          <Button
+            type="text"
+            size="small"
+            icon={<SnippetsOutlined />}
+            onClick={onPaste}
+          />
+        </Tooltip>
+        <Tooltip
+          title={
+            tabCount >= MAX_TABS
+              ? t('terminal.tabs.maxReached', { max: MAX_TABS })
+              : t('terminal.toolbar.newTab')
+          }
+        >
+          <Button
+            type="text"
+            size="small"
+            icon={<PlusOutlined />}
+            onClick={onAddTab}
+            disabled={tabCount >= MAX_TABS}
+          />
+        </Tooltip>
+        <Tooltip
+          title={
+            isFullscreen
+              ? t('terminal.toolbar.exitFullscreen')
+              : t('terminal.toolbar.fullscreen')
+          }
+        >
+          <Button
+            type="text"
+            size="small"
+            icon={isFullscreen ? <FullscreenExitOutlined /> : <FullscreenOutlined />}
+            onClick={onToggleFullscreen}
+          />
+        </Tooltip>
+      </Space>
+    </div>
+  );
+};
+
+export default TerminalToolbar;

--- a/easyshell-web/src/pages/terminal/hooks/useFileManager.ts
+++ b/easyshell-web/src/pages/terminal/hooks/useFileManager.ts
@@ -1,0 +1,227 @@
+import { useState, useCallback } from 'react';
+import { message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import request from '../../../api/request';
+
+export interface FileInfo {
+  name: string;
+  isDir: boolean;
+  size: number;
+  mode: string;
+  modTime: number;
+}
+
+interface UseFileManagerReturn {
+  files: FileInfo[];
+  currentPath: string;
+  loading: boolean;
+  error: string | null;
+  uploadProgress: number | null;
+  uploadPhase: 'uploading' | 'transferring' | null;
+  downloadProgress: number | null;
+  navigate: (path: string) => Promise<void>;
+  upload: (file: File) => Promise<void>;
+  download: (path: string, fileName: string) => Promise<void>;
+  mkdir: (name: string) => Promise<void>;
+  remove: (path: string) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  goUp: () => Promise<void>;
+}
+
+export function useFileManager(agentId: string): UseFileManagerReturn {
+  const { t } = useTranslation();
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [currentPath, setCurrentPath] = useState('/');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
+  const [uploadPhase, setUploadPhase] = useState<'uploading' | 'transferring' | null>(null);
+
+  const navigate = useCallback(async (path: string) => {
+    if (!agentId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await request.get<any, { code: number, data: FileInfo[], message: string }>(
+        `/v1/agents/${agentId}/files`,
+        { params: { path } }
+      );
+      if (response.code === 200) {
+        setFiles(response.data || []);
+        setCurrentPath(path);
+      } else {
+        throw new Error(response.message || 'Failed to list files');
+      }
+    } catch (err: any) {
+      const errMsg = err.message || 'Unknown error';
+      setError(errMsg);
+      message.error(t('terminal.files.operationFailed', { error: errMsg }));
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId, t]);
+
+  const upload = useCallback(async (file: File) => {
+    if (!agentId) return;
+    setUploadProgress(0);
+    setUploadPhase('uploading');
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      
+      const response = await request.post<any, { code: number, message: string }>(
+        `/v1/agents/${agentId}/files/upload`,
+        formData,
+        {
+          params: { path: currentPath },
+          headers: { 'Content-Type': 'multipart/form-data' },
+          timeout: 0, // No timeout for file uploads
+          onUploadProgress: (progressEvent) => {
+            if (progressEvent.total) {
+              const percent = Math.round((progressEvent.loaded * 100) / progressEvent.total);
+              setUploadProgress(percent);
+              if (percent >= 100) {
+                setUploadPhase('transferring');
+              }
+            }
+          },
+        }
+      );
+      
+      if (response.code === 200) {
+        message.success(t('terminal.files.uploadSuccess'));
+        await navigate(currentPath);
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (err: any) {
+      message.error(t('terminal.files.operationFailed', { error: err.message }));
+    } finally {
+      setUploadProgress(null);
+      setUploadPhase(null);
+    }
+  }, [agentId, currentPath, navigate, t]);
+
+  const download = useCallback(async (path: string, fileName: string) => {
+    if (!agentId) return;
+    setDownloadProgress(0);
+    try {
+      const token = localStorage.getItem('token');
+      const url = `/api/v1/agents/${agentId}/files/download?path=${encodeURIComponent(path)}`;
+
+      const blob: Blob = await new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.responseType = 'blob';
+        if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+
+        xhr.onprogress = (event) => {
+          if (event.lengthComputable && event.total > 0) {
+            const percent = Math.round((event.loaded * 100) / event.total);
+            setDownloadProgress(percent);
+          }
+        };
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve(xhr.response as Blob);
+          } else {
+            reject(new Error(`Download failed with status ${xhr.status}`));
+          }
+        };
+
+        xhr.onerror = () => reject(new Error('Download failed'));
+        xhr.ontimeout = () => reject(new Error('Download timed out'));
+        xhr.timeout = 0; // No timeout for file downloads
+        xhr.send();
+      });
+
+      const blobUrl = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(blobUrl);
+      message.success(t('terminal.files.downloadSuccess', 'Download completed'));
+    } catch (err: any) {
+      message.error(t('terminal.files.operationFailed', { error: err.message }));
+    } finally {
+      setDownloadProgress(null);
+    }
+  }, [agentId, t]);
+
+  const mkdir = useCallback(async (name: string) => {
+    if (!agentId) return;
+    try {
+      const fullPath = currentPath.endsWith('/') ? `${currentPath}${name}` : `${currentPath}/${name}`;
+      const response = await request.post<any, { code: number, message: string }>(
+        `/v1/agents/${agentId}/files/mkdir`,
+        null,
+        { params: { path: fullPath } }
+      );
+      
+      if (response.code === 200) {
+        await navigate(currentPath);
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (err: any) {
+      message.error(t('terminal.files.operationFailed', { error: err.message }));
+    }
+  }, [agentId, currentPath, navigate, t]);
+
+  const remove = useCallback(async (path: string) => {
+    if (!agentId) return;
+    try {
+      const response = await request.delete<any, { code: number, message: string }>(
+        `/v1/agents/${agentId}/files`,
+        { params: { path } }
+      );
+      
+      if (response.code === 200) {
+        await navigate(currentPath);
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (err: any) {
+      message.error(t('terminal.files.operationFailed', { error: err.message }));
+    }
+  }, [agentId, currentPath, navigate, t]);
+
+  const rename = useCallback(async (oldPath: string, newPath: string) => {
+    if (!agentId) return;
+    try {
+      const response = await request.put<any, { code: number, message: string }>(
+        `/v1/agents/${agentId}/files/rename`,
+        { oldPath, newPath }
+      );
+      
+      if (response.code === 200) {
+        await navigate(currentPath);
+      } else {
+        throw new Error(response.message);
+      }
+    } catch (err: any) {
+      message.error(t('terminal.files.operationFailed', { error: err.message }));
+    }
+  }, [agentId, currentPath, navigate, t]);
+
+  const refresh = useCallback(async () => {
+    await navigate(currentPath);
+  }, [currentPath, navigate]);
+
+  const goUp = useCallback(async () => {
+    if (currentPath === '/') return;
+    const parent = currentPath.substring(0, currentPath.lastIndexOf('/')) || '/';
+    await navigate(parent);
+  }, [currentPath, navigate]);
+
+  return {
+    files, currentPath, loading, error, uploadProgress, uploadPhase, downloadProgress,
+    navigate, upload, download, mkdir, remove, rename, refresh, goUp,
+  };
+}

--- a/easyshell-web/src/pages/terminal/index.tsx
+++ b/easyshell-web/src/pages/terminal/index.tsx
@@ -1,44 +1,25 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Button, Space, Typography, theme, Tooltip } from 'antd';
 import { ArrowLeftOutlined, CodeOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useResponsive } from '../../hooks/useResponsive';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
-import '@xterm/xterm/css/xterm.css';
+import TerminalInstance from './components/TerminalInstance';
+import type { TerminalInstanceRef } from './components/TerminalInstance';
+import TerminalTabs from './components/TerminalTabs';
+import TerminalToolbar from './components/TerminalToolbar';
+import SearchBar from './components/SearchBar';
+import type { TerminalTab, ConnectionStatus } from './types';
+import { statusConfig, terminalTheme } from './types';
+import FileManager from './components/FileManager';
 
-type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
+let tabCounter = 1;
 
-const statusConfig: Record<ConnectionStatus, { color: string; textKey: string }> = {
-  connecting: { color: '#faad14', textKey: 'terminal.connecting' },
-  connected: { color: '#52c41a', textKey: 'terminal.connected' },
-  disconnected: { color: '#ff4d4f', textKey: 'terminal.disconnected' },
-};
-
-const terminalTheme = {
-  background: '#1a1b2e',
-  foreground: '#e4e4e8',
-  cursor: '#2563eb',
-  selectionBackground: 'rgba(37, 99, 235, 0.3)',
-  black: '#1a1b2e',
-  red: '#ff5555',
-  green: '#50fa7b',
-  yellow: '#f1fa8c',
-  blue: '#2563eb',
-  magenta: '#bd93f9',
-  cyan: '#8be9fd',
-  white: '#e4e4e8',
-  brightBlack: '#6272a4',
-  brightRed: '#ff6e6e',
-  brightGreen: '#69ff94',
-  brightYellow: '#ffffa5',
-  brightBlue: '#60a5fa',
-  brightMagenta: '#d6acff',
-  brightCyan: '#a4ffff',
-  brightWhite: '#ffffff',
-};
+function createTab(agentId: string): TerminalTab {
+  const id = crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  const label = `Terminal ${tabCounter++}`;
+  return { id, label, agentId, status: 'connecting' };
+}
 
 const TerminalPage: React.FC = () => {
   const { token } = theme.useToken();
@@ -46,145 +27,147 @@ const TerminalPage: React.FC = () => {
   const { isMobile } = useResponsive();
   const { agentId } = useParams<{ agentId: string }>();
   const navigate = useNavigate();
-  const terminalRef = useRef<HTMLDivElement>(null);
-  const termInstanceRef = useRef<Terminal | null>(null);
-  const wsRef = useRef<WebSocket | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const [status, setStatus] = useState<ConnectionStatus>('connecting');
+
+  const [tabs, setTabs] = useState<TerminalTab[]>(() =>
+    agentId ? [createTab(agentId)] : []
+  );
+  const [activeTabId, setActiveTabId] = useState<string>(() =>
+    tabs.length > 0 ? tabs[0].id : ''
+  );
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isFileManagerOpen, setIsFileManagerOpen] = useState(true);
+  const [searchVisible, setSearchVisible] = useState(false);
+
+  // Refs map for terminal instances
+  const instanceRefs = useRef<Map<string, TerminalInstanceRef>>(new Map());
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const setInstanceRef = useCallback((tabId: string) => (ref: TerminalInstanceRef | null) => {
+    if (ref) {
+      instanceRefs.current.set(tabId, ref);
+    } else {
+      instanceRefs.current.delete(tabId);
+    }
+  }, []);
+
+  const activeInstance = activeTabId ? instanceRefs.current.get(activeTabId) : null;
+
+  // Tab management
+  const handleAddTab = useCallback(() => {
+    if (!agentId || tabs.length >= 8) return;
+    const newTab = createTab(agentId);
+    setTabs(prev => [...prev, newTab]);
+    setActiveTabId(newTab.id);
+  }, [agentId, tabs.length]);
+
+  const handleCloseTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const newTabs = prev.filter(t => t.id !== tabId);
+      if (newTabs.length === 0) {
+        navigate(-1);
+        return prev;
+      }
+      return newTabs;
+    });
+    if (activeTabId === tabId) {
+      setTabs(prev => {
+        const idx = prev.findIndex(t => t.id === tabId);
+        const newActive = prev[idx > 0 ? idx - 1 : idx + 1];
+        if (newActive) setActiveTabId(newActive.id);
+        return prev;
+      });
+    }
+    instanceRefs.current.delete(tabId);
+  }, [activeTabId, navigate]);
+
+  const handleRenameTab = useCallback((tabId: string, newLabel: string) => {
+    setTabs(prev => prev.map(t => t.id === tabId ? { ...t, label: newLabel } : t));
+  }, []);
+
+  const handleStatusChange = useCallback((tabId: string, status: ConnectionStatus) => {
+    setTabs(prev => prev.map(t => t.id === tabId ? { ...t, status } : t));
+  }, []);
+
+  // Fullscreen
+  const handleToggleFullscreen = useCallback(() => {
+    if (!document.fullscreenElement) {
+      containerRef.current?.requestFullscreen();
+      setIsFullscreen(true);
+    } else {
+      document.exitFullscreen();
+      setIsFullscreen(false);
+    }
+  }, []);
 
   useEffect(() => {
-    if (!terminalRef.current || !agentId) return;
+    const handler = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', handler);
+    return () => document.removeEventListener('fullscreenchange', handler);
+  }, []);
 
-    const term = new Terminal({
-      cursorBlink: true,
-      fontSize: 14,
-      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, Monaco, monospace",
-      theme: terminalTheme,
-      allowProposedApi: true,
-      scrollback: 5000,
-      convertEol: true,
-    });
-
-    const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
-
-    term.loadAddon(fitAddon);
-    term.loadAddon(webLinksAddon);
-    term.open(terminalRef.current);
-
-    termInstanceRef.current = term;
-    fitAddonRef.current = fitAddon;
-
-    setTimeout(() => fitAddon.fit(), 100);
-
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}/ws/terminal/${agentId}`;
-    const ws = new WebSocket(wsUrl);
-    wsRef.current = ws;
-
-    term.writeln('\x1b[36m[' + t('terminal.system') + ']\x1b[0m ' + t('terminal.connectingHost'));
-
-    ws.onopen = () => {
-      term.writeln('\x1b[36m[' + t('terminal.system') + ']\x1b[0m ' + t('terminal.wsConnected'));
-    };
-
-    ws.onmessage = (event: MessageEvent) => {
-      try {
-        const msg = JSON.parse(event.data as string) as { type: string; data?: string };
-        switch (msg.type) {
-          case 'terminal_ready':
-            setStatus('connected');
-            setTimeout(() => {
-              fitAddon.fit();
-              ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
-            }, 200);
-            break;
-          case 'output':
-            if (msg.data) {
-              term.write(msg.data);
-            }
-            break;
-          case 'error':
-          case 'terminal_error':
-            term.writeln(`\x1b[31m[${t('terminal.error')}]\x1b[0m ${msg.data || t('terminal.unknownError')}`);
-            break;
-        }
-      } catch {
-        term.write(event.data as string);
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key === 'F') {
+        e.preventDefault();
+        setSearchVisible(v => !v);
       }
     };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
-    ws.onclose = () => {
-      setStatus('disconnected');
-      term.writeln('\r\n\x1b[33m[' + t('terminal.system') + ']\x1b[0m ' + t('terminal.disconnectedRefresh'));
-    };
+  // Toolbar handlers
+  const handleCopy = useCallback(() => {
+    activeInstance?.copySelection();
+  }, [activeInstance]);
 
-    ws.onerror = () => {
-      setStatus('disconnected');
-      term.writeln('\r\n\x1b[31m[' + t('terminal.system') + ']\x1b[0m ' + t('terminal.connectionError'));
-    };
+  const handlePaste = useCallback(() => {
+    activeInstance?.pasteFromClipboard();
+  }, [activeInstance]);
 
-    const inputDisposable = term.onData((data: string) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'input', data }));
-      }
-    });
+  const handleToggleSearch = useCallback(() => {
+    setSearchVisible(v => !v);
+  }, []);
 
-    const resizeDisposable = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'resize', cols, rows }));
-      }
-    });
+  const handleToggleFiles = useCallback(() => {
+    setIsFileManagerOpen(v => !v);
+  }, []);
 
-    const handleResize = () => {
-      if (fitAddonRef.current) {
-        fitAddonRef.current.fit();
-      }
-    };
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-      inputDisposable.dispose();
-      resizeDisposable.dispose();
-      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-        ws.close();
-      }
-      term.dispose();
-      termInstanceRef.current = null;
-      wsRef.current = null;
-      fitAddonRef.current = null;
-    };
-  }, [agentId]);
-
-  const statusInfo = statusConfig[status];
+  // Get active tab status for header display
+  const activeTab = tabs.find(t => t.id === activeTabId);
+  const statusInfo = statusConfig[activeTab?.status || 'disconnected'];
 
   return (
-    <div style={{ 
-      display: 'flex', 
-      flexDirection: 'column', 
-      height: 'var(--content-inner-height)',
-      minHeight: 0,
-    }}>
+    <div
+      ref={containerRef}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: 'var(--content-inner-height)',
+        minHeight: 0,
+        background: isFullscreen ? terminalTheme.background : undefined,
+      }}
+    >
       {/* Header */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        marginBottom: isMobile ? 8 : 12,
+        marginBottom: isMobile ? 4 : 8,
         flexWrap: isMobile ? 'wrap' : 'nowrap',
         gap: 8,
       }}>
         <Space size={isMobile ? 'small' : 'middle'}>
-          <Button 
-            icon={<ArrowLeftOutlined />} 
+          <Button
+            icon={<ArrowLeftOutlined />}
             onClick={() => navigate(-1)}
             size={isMobile ? 'small' : 'middle'}
           >
             {!isMobile && t('common.back')}
           </Button>
-          <Typography.Title 
-            level={isMobile ? 5 : 4} 
+          <Typography.Title
+            level={isMobile ? 5 : 4}
             style={{ margin: 0, color: token.colorText }}
           >
             <CodeOutlined style={{ marginRight: 8, color: token.colorPrimary }} />
@@ -221,24 +204,67 @@ const TerminalPage: React.FC = () => {
         </Space>
       </div>
 
-      {/* Terminal Container */}
-      <div style={{
-        flex: 1,
-        borderRadius: isMobile ? 8 : 12,
-        background: terminalTheme.background,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        overflow: 'hidden',
-        boxShadow: '0 4px 24px rgba(0, 0, 0, 0.2)',
-        minHeight: 0,
-      }}>
-        <div
-          ref={terminalRef}
-          style={{
-            width: '100%',
-            height: '100%',
-            padding: isMobile ? 4 : 8,
-          }}
-        />
+      {/* Toolbar */}
+      <TerminalToolbar
+        onToggleFiles={handleToggleFiles}
+        onSearch={handleToggleSearch}
+        onAddTab={handleAddTab}
+        onToggleFullscreen={handleToggleFullscreen}
+        onCopy={handleCopy}
+        onPaste={handlePaste}
+        isFullscreen={isFullscreen}
+        isFileManagerOpen={isFileManagerOpen}
+        tabCount={tabs.length}
+      />
+
+      {/* Tabs */}
+      <TerminalTabs
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onTabChange={setActiveTabId}
+        onTabClose={handleCloseTab}
+        onTabAdd={handleAddTab}
+        onTabRename={handleRenameTab}
+      />
+
+      {/* Terminal area + File manager */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0 }}>
+        <div style={{
+          flex: 1,
+          position: 'relative',
+          borderRadius: isMobile ? 8 : 12,
+          background: terminalTheme.background,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          overflow: 'hidden',
+          boxShadow: '0 4px 24px rgba(0, 0, 0, 0.2)',
+          minHeight: 0,
+        }}>
+          {tabs.map(tab => (
+            <TerminalInstance
+              key={tab.id}
+              ref={setInstanceRef(tab.id)}
+              tabId={tab.id}
+              agentId={tab.agentId}
+              isActive={tab.id === activeTabId}
+              onStatusChange={handleStatusChange}
+            />
+          ))}
+          {/* Search overlay */}
+          <SearchBar
+            searchAddon={activeInstance?.searchAddon || null}
+            visible={searchVisible}
+            onClose={() => setSearchVisible(false)}
+          />
+        </div>
+
+        {/* Phase 2: FileManager sidebar */}
+        {isFileManagerOpen && agentId && (
+          <FileManager 
+            agentId={agentId} 
+            visible={isFileManagerOpen} 
+            onClose={() => setIsFileManagerOpen(false)} 
+          />
+        )}
       </div>
     </div>
   );

--- a/easyshell-web/src/pages/terminal/types.ts
+++ b/easyshell-web/src/pages/terminal/types.ts
@@ -1,0 +1,46 @@
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
+
+export interface TerminalTab {
+  id: string;
+  label: string;
+  agentId: string;
+  status: ConnectionStatus;
+}
+
+export interface TerminalSettings {
+  fontSize: number;
+  fontFamily: string;
+  theme: 'dark' | 'dracula' | 'solarized' | 'monokai' | 'light';
+  scrollback: number;
+}
+
+export const MAX_TABS = 8;
+
+export const statusConfig: Record<ConnectionStatus, { color: string; textKey: string }> = {
+  connecting: { color: '#faad14', textKey: 'terminal.connecting' },
+  connected: { color: '#52c41a', textKey: 'terminal.connected' },
+  disconnected: { color: '#ff4d4f', textKey: 'terminal.disconnected' },
+};
+
+export const terminalTheme = {
+  background: '#1a1b2e',
+  foreground: '#e4e4e8',
+  cursor: '#2563eb',
+  selectionBackground: 'rgba(37, 99, 235, 0.3)',
+  black: '#1a1b2e',
+  red: '#ff5555',
+  green: '#50fa7b',
+  yellow: '#f1fa8c',
+  blue: '#2563eb',
+  magenta: '#bd93f9',
+  cyan: '#8be9fd',
+  white: '#e4e4e8',
+  brightBlack: '#6272a4',
+  brightRed: '#ff6e6e',
+  brightGreen: '#69ff94',
+  brightYellow: '#ffffa5',
+  brightBlue: '#60a5fa',
+  brightMagenta: '#d6acff',
+  brightCyan: '#a4ffff',
+  brightWhite: '#ffffff',
+};


### PR DESCRIPTION
## Summary
- **Web 终端文件管理器**：浏览、上传、下载、新建文件夹、重命名、删除远程主机文件
- **文件传输进度优化**：上传/下载实时进度条，上传二阶段提示（转存到目标服务器）
- **分离超时策略**：普通 API 30s，文件传输无超时（nginx + axios + Spring 全链路）
- **Agent 0.2.2**：新增文件服务模块，旧版本主机自动提示重装更新

## Changes (32 files, +4833 / -181)

### Agent (Go)
- `easyshell-agent/internal/fileserver/` — 新增安全文件服务（路径遍历防护、可配置允许路径）
- `easyshell-agent/cmd/agent/main.go` — 集成文件服务，版本升级 0.2.2

### Server (Java)
- `FileProxyController.java` — 文件代理 REST 端点（list/upload/download/mkdir/rename/delete）
- `FileProxyServiceImpl.java` — WebSocket 分块文件传输，上传重试 3 次，24h 超时兜底
- `AgentWebSocketHandler.java` — 文件操作消息路由
- `application.yml` — async request-timeout: -1

### Web (React)
- `terminal/components/FileManager.tsx` — 文件管理器 UI 面板
- `terminal/hooks/useFileManager.ts` — 文件操作 hook，二阶段上传进度
- `terminal/components/FileTree.tsx` — 文件树组件
- `host/index.tsx` — LATEST_AGENT_VERSION → 0.2.2，旧版本警告提示
- `nginx.conf` — 文件传输专用 location 块（500MB 限制、86400s 超时）
- `request.ts` — 全局 axios 超时 30s
- i18n 新增文件管理器全量中英文翻译

### Docs
- PRD & 技术规格文档

## Bug Fixes
- 修复 nginx `proxy_read_timeout 0` 导致 504
- 添加主机"立即部署"默认改为不勾选